### PR TITLE
Improve invoice download reliability on My Account orders

### DIFF
--- a/assets/js/customer.js
+++ b/assets/js/customer.js
@@ -41,6 +41,18 @@
                 }
             }
 
+            // Invoice fragment: #b2brouter-invoice-{order_id}-{order_key}
+            if (href && href.indexOf('#b2brouter-invoice-') === 0) {
+                var invoiceMatch = href.match(/#b2brouter-invoice-(\d+)-(.+)$/);
+                if (invoiceMatch) {
+                    orderId = invoiceMatch[1];
+                    orderKey = invoiceMatch[2];
+                    if (b2brouterCustomer.debug) {
+                        console.log('Extracted order ID and key from invoice fragment:', orderId, orderKey);
+                    }
+                }
+            }
+
             // Get order ID from My Account table if not set
             if (!orderId) {
                 // Try to extract from aria-label first (e.g., "Download Invoice PDF order number 70")

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -131,7 +131,7 @@ class Customer {
         // If invoice exists, show download button
         if (!empty($invoice_id)) {
             $actions['b2brouter_download_invoice'] = array(
-                'url' => 'javascript:void(0);',
+                'url' => '#b2brouter-invoice-' . $order->get_id() . '-' . $order->get_order_key(),
                 'name' => __('Download Invoice', 'b2brouter-woocommerce'),
             );
         }


### PR DESCRIPTION
Carry the order ID and key in the action URL fragment instead of relying on JS heuristics (aria-label text, row URL regex) that broke on non-English locales and renamed view-order endpoints.