### PR TITLE
Switch from error_log() to wc_get_logger() (closes #12)

### DIFF
--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -249,7 +249,7 @@ class Invoice_Generator {
                 } catch (\Exception $e) {
                     // PDF download failed after retries, but invoice was created successfully
                     // Log the error but don't fail the entire operation
-                    error_log('B2Brouter auto-save PDF failed after retries: ' . $e->getMessage());
+                    Logger::error('B2Brouter auto-save PDF failed after retries: ' . $e->getMessage());
                 }
             }
 
@@ -267,7 +267,7 @@ class Invoice_Generator {
 
         } catch (\Exception $e) {
             // Log error
-            error_log('B2Brouter Invoice Generation Error: ' . $e->getMessage());
+            Logger::error('B2Brouter Invoice Generation Error: ' . $e->getMessage());
 
             // Add order note with error
             if (isset($order) && $order) {
@@ -715,28 +715,28 @@ class Invoice_Generator {
             );
 
         } catch (\B2BRouter\Exception\ResourceNotFoundException $e) {
-            error_log('B2Brouter PDF Download - Invoice not found: ' . $invoice_id);
+            Logger::error('B2Brouter PDF Download - Invoice not found: ' . $invoice_id);
             return array(
                 'success' => false,
                 'message' => __('Invoice not found', 'b2brouter-woocommerce')
             );
 
         } catch (\B2BRouter\Exception\AuthenticationException $e) {
-            error_log('B2Brouter PDF Download - Authentication failed: ' . $e->getMessage());
+            Logger::error('B2Brouter PDF Download - Authentication failed: ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => __('API authentication failed. Please check your API key.', 'b2brouter-woocommerce')
             );
 
         } catch (\B2BRouter\Exception\PermissionException $e) {
-            error_log('B2Brouter PDF Download - Permission denied: ' . $e->getMessage());
+            Logger::error('B2Brouter PDF Download - Permission denied: ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => __('You do not have permission to download this invoice.', 'b2brouter-woocommerce')
             );
 
         } catch (\B2BRouter\Exception\ApiErrorException $e) {
-            error_log('B2Brouter PDF Download - API error: ' . $e->getMessage());
+            Logger::error('B2Brouter PDF Download - API error: ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => sprintf(
@@ -746,7 +746,7 @@ class Invoice_Generator {
             );
 
         } catch (\Exception $e) {
-            error_log('B2Brouter PDF Download - Error: ' . $e->getMessage());
+            Logger::error('B2Brouter PDF Download - Error: ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => $e->getMessage()
@@ -844,7 +844,7 @@ class Invoice_Generator {
             );
 
         } catch (\Exception $e) {
-            error_log('B2Brouter Save PDF Error: ' . $e->getMessage());
+            Logger::error('B2Brouter Save PDF Error: ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => $e->getMessage()
@@ -978,7 +978,7 @@ class Invoice_Generator {
             exit;
 
         } catch (\Exception $e) {
-            error_log('B2Brouter Stream PDF Error: ' . $e->getMessage());
+            Logger::error('B2Brouter Stream PDF Error: ' . $e->getMessage());
             wp_die(
                 esc_html($e->getMessage()),
                 esc_html__('Error', 'b2brouter-woocommerce'),
@@ -1160,7 +1160,7 @@ class Invoice_Generator {
             if ($save_result['success']) {
                 $pdf_path = $save_result['file_path'];
             } else {
-                error_log('B2Brouter Email Attachment: Failed to get PDF for order ' . $order->get_id());
+                Logger::warning('B2Brouter Email Attachment: Failed to get PDF for order ' . $order->get_id());
                 return $attachments;
             }
         }
@@ -1208,7 +1208,7 @@ class Invoice_Generator {
                     $this->cleanup_order_metadata_for_file($file);
                 } else {
                     $errors++;
-                    error_log('B2Brouter Cleanup: Failed to delete ' . $file);
+                    Logger::warning('B2Brouter Cleanup: Failed to delete ' . $file);
                 }
             }
         }

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Logger
+ *
+ * Thin wrapper around wc_get_logger() that pins the source to
+ * 'b2brouter-woocommerce' so plugin entries are filterable in
+ * WooCommerce > Status > Logs.
+ *
+ * @package B2Brouter\WooCommerce
+ * @since 0.9.4
+ */
+
+namespace B2Brouter\WooCommerce;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Logger class
+ *
+ * @since 0.9.4
+ */
+class Logger {
+
+    const SOURCE = 'b2brouter-woocommerce';
+
+    /**
+     * Log an error-level message.
+     *
+     * @since 0.9.4
+     * @param string $message Message
+     * @param array  $context Optional context (merged with source)
+     * @return void
+     */
+    public static function error($message, array $context = array()) {
+        self::log('error', $message, $context);
+    }
+
+    /**
+     * Log a warning-level message.
+     *
+     * @since 0.9.4
+     * @param string $message Message
+     * @param array  $context Optional context (merged with source)
+     * @return void
+     */
+    public static function warning($message, array $context = array()) {
+        self::log('warning', $message, $context);
+    }
+
+    /**
+     * Log an info-level message.
+     *
+     * @since 0.9.4
+     * @param string $message Message
+     * @param array  $context Optional context (merged with source)
+     * @return void
+     */
+    public static function info($message, array $context = array()) {
+        self::log('info', $message, $context);
+    }
+
+    /**
+     * Dispatch to wc_get_logger(). No-ops if WooCommerce hasn't loaded.
+     *
+     * @since 0.9.4
+     * @param string $level   PSR-3 level ('error', 'warning', 'info', ...)
+     * @param string $message Message
+     * @param array  $context Context
+     * @return void
+     */
+    private static function log($level, $message, array $context) {
+        if (!function_exists('wc_get_logger')) {
+            return;
+        }
+
+        $logger = wc_get_logger();
+
+        if (!$logger) {
+            return;
+        }
+
+        $context['source'] = self::SOURCE;
+        $logger->log($level, $message, $context);
+    }
+}

--- a/includes/Order_Handler.php
+++ b/includes/Order_Handler.php
@@ -714,7 +714,7 @@ class Order_Handler {
 
         // Log the cleanup
         if ($result['deleted'] > 0 || $result['errors'] > 0) {
-            error_log(sprintf(
+            Logger::info(sprintf(
                 'B2Brouter PDF Cleanup: Deleted %d files, %d errors (older than %d days)',
                 $result['deleted'],
                 $result['errors'],

--- a/includes/Status_Sync.php
+++ b/includes/Status_Sync.php
@@ -331,24 +331,28 @@ class Status_Sync {
             );
 
         } catch (\B2BRouter\Exception\ResourceNotFoundException $e) {
+            Logger::warning('B2Brouter Status Sync - Invoice not found for order ' . $order_id . ' (invoice ' . $invoice_id . ')');
             return array(
                 'success' => false,
                 'message' => __('Invoice not found in B2Brouter', 'b2brouter-woocommerce')
             );
 
         } catch (\B2BRouter\Exception\AuthenticationException $e) {
+            Logger::error('B2Brouter Status Sync - Authentication failed: ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => __('API authentication failed', 'b2brouter-woocommerce')
             );
 
         } catch (\B2BRouter\Exception\ApiErrorException $e) {
+            Logger::error('B2Brouter Status Sync - API error for order ' . $order_id . ': ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => sprintf(__('API error: %s', 'b2brouter-woocommerce'), $e->getMessage())
             );
 
         } catch (\Exception $e) {
+            Logger::error('B2Brouter Status Sync - Error for order ' . $order_id . ': ' . $e->getMessage());
             return array(
                 'success' => false,
                 'message' => $e->getMessage()

--- a/includes/Webhook_Handler.php
+++ b/includes/Webhook_Handler.php
@@ -88,7 +88,7 @@ class Webhook_Handler {
 
         // Verify webhook signature
         if (!$this->verify_webhook_signature($request, $raw_body)) {
-            error_log('B2Brouter webhook signature verification failed');
+            Logger::error('B2Brouter webhook signature verification failed');
             return new \WP_REST_Response(array(
                 'error' => 'Invalid signature'
             ), 401);
@@ -98,7 +98,7 @@ class Webhook_Handler {
         $payload = json_decode($raw_body, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            error_log('B2Brouter webhook invalid JSON payload');
+            Logger::error('B2Brouter webhook invalid JSON payload');
             return new \WP_REST_Response(array(
                 'error' => 'Invalid JSON payload'
             ), 400);
@@ -106,7 +106,7 @@ class Webhook_Handler {
 
         // Validate payload structure
         if (!isset($payload['code']) || !isset($payload['data'])) {
-            error_log('B2Brouter webhook missing required fields');
+            Logger::error('B2Brouter webhook missing required fields');
             return new \WP_REST_Response(array(
                 'error' => 'Missing required fields'
             ), 400);
@@ -139,7 +139,7 @@ class Webhook_Handler {
         $webhook_secret = $this->settings->get_webhook_secret();
 
         if (empty($webhook_secret)) {
-            error_log('B2Brouter webhook secret not configured');
+            Logger::error('B2Brouter webhook secret not configured');
             return false;
         }
 
@@ -147,7 +147,7 @@ class Webhook_Handler {
         $signature_header = $request->get_header('X-B2Brouter-Signature');
 
         if (empty($signature_header)) {
-            error_log('B2Brouter webhook missing X-B2Brouter-Signature header');
+            Logger::error('B2Brouter webhook missing X-B2Brouter-Signature header');
             return false;
         }
 
@@ -161,7 +161,7 @@ class Webhook_Handler {
         }
 
         if (!isset($parts['t']) || !isset($parts['s'])) {
-            error_log('B2Brouter webhook invalid signature header format');
+            Logger::error('B2Brouter webhook invalid signature header format');
             return false;
         }
 
@@ -170,7 +170,7 @@ class Webhook_Handler {
 
         // Verify timestamp is within 5 minutes (prevent replay attacks)
         if (abs(time() - $timestamp) > 300) {
-            error_log('B2Brouter webhook timestamp outside valid window');
+            Logger::error('B2Brouter webhook timestamp outside valid window');
             return false;
         }
 
@@ -199,7 +199,7 @@ class Webhook_Handler {
                 return $this->process_invoice_status_change($payload['data']);
 
             default:
-                error_log(sprintf('B2Brouter webhook unsupported event type: %s', $event_code));
+                Logger::warning(sprintf('B2Brouter webhook unsupported event type: %s', $event_code));
                 return array(
                     'success' => false,
                     'message' => 'Unsupported event type',
@@ -233,7 +233,7 @@ class Webhook_Handler {
         $order_id = $this->find_order_by_invoice_id($invoice_id);
 
         if (!$order_id) {
-            error_log(sprintf(
+            Logger::warning(sprintf(
                 'B2Brouter webhook received for unknown invoice ID: %d',
                 $invoice_id
             ));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -196,6 +196,34 @@ if (!function_exists('error_log')) {
     }
 }
 
+if (!function_exists('wc_get_logger')) {
+    /**
+     * Mock wc_get_logger function
+     *
+     * Returns a no-op logger with error/warning/info/log methods so calls
+     * from B2Brouter\WooCommerce\Logger don't fail under test.
+     *
+     * @return object Logger stub
+     */
+    function wc_get_logger() {
+        static $logger = null;
+        if ($logger === null) {
+            $logger = new class {
+                public function log($level, $message, $context = array()) {}
+                public function error($message, $context = array()) {}
+                public function warning($message, $context = array()) {}
+                public function info($message, $context = array()) {}
+                public function debug($message, $context = array()) {}
+                public function notice($message, $context = array()) {}
+                public function critical($message, $context = array()) {}
+                public function alert($message, $context = array()) {}
+                public function emergency($message, $context = array()) {}
+            };
+        }
+        return $logger;
+    }
+}
+
 if (!function_exists('wp_die')) {
     /**
      * Mock wp_die function


### PR DESCRIPTION
Add Logger wrapper pinning source to 'b2brouter-woocommerce' so entries surface in WooCommerce > Status > Logs. Replace 21 error_log() calls across Invoice_Generator, Webhook_Handler, and Order_Handler with appropriate levels. Also log previously-silent catches in Status_Sync::sync_single_invoice.

Levels: signature/config/API/auth failures use error; unsupported webhook events, unknown invoice IDs, cleanup delete failures, and missing-attachment fallbacks use warning; cleanup summary uses info.