### PR TITLE
Complete WP Filesystem migration for PDF reads, listing, uninstall.

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -458,6 +458,53 @@ class Admin {
     }
 
     /**
+     * Get PDF cache statistics for the settings-page summary.
+     *
+     * Returns null when the storage directory is missing or the WordPress
+     * Filesystem API cannot be initialised — the caller renders the
+     * "directory will be created" placeholder for both cases.
+     *
+     * @since 1.0.0
+     * @return array{count: int, total_size: int}|null
+     */
+    public function get_pdf_storage_stats() {
+        $storage_path = $this->settings->get_pdf_storage_path();
+
+        if (!file_exists($storage_path)) {
+            return null;
+        }
+
+        if (!function_exists('WP_Filesystem')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        global $wp_filesystem;
+
+        if (!WP_Filesystem()) {
+            return null;
+        }
+
+        $entries = $wp_filesystem->dirlist($storage_path);
+
+        if (empty($entries)) {
+            return array('count' => 0, 'total_size' => 0);
+        }
+
+        $count = 0;
+        $total_size = 0;
+
+        foreach ($entries as $entry) {
+            if ($entry['type'] !== 'f' || substr($entry['name'], -4) !== '.pdf') {
+                continue;
+            }
+            $count++;
+            $total_size += (int) $entry['size'];
+        }
+
+        return array('count' => $count, 'total_size' => $total_size);
+    }
+
+    /**
      * Render settings page
      *
      * @since 1.0.0
@@ -936,24 +983,16 @@ class Admin {
                                 <?php esc_html_e('Invoice PDFs are stored in this directory. Files are protected from direct access via .htaccess rules.', 'b2brouter-woocommerce'); ?>
                             </p>
                             <?php
-                            $storage_path = $this->settings->get_pdf_storage_path();
-                            if (file_exists($storage_path)) {
-                                $pdf_files = glob($storage_path . '/*.pdf');
-                                $pdf_count = $pdf_files ? count($pdf_files) : 0;
-                                $total_size = 0;
-                                if ($pdf_files) {
-                                    foreach ($pdf_files as $file) {
-                                        $total_size += filesize($file);
-                                    }
-                                }
+                            $stats = $this->get_pdf_storage_stats();
+                            if ($stats !== null) {
                                 ?>
                                 <p class="description">
                                     <span class="dashicons dashicons-yes-alt" style="color: #46b450;"></span>
                                     <?php
                                     printf(
                                         esc_html__('Currently storing %d PDF(s) using %s of disk space', 'b2brouter-woocommerce'),
-                                        $pdf_count,
-                                        size_format($total_size, 2)
+                                        $stats['count'],
+                                        size_format($stats['total_size'], 2)
                                     );
                                     ?>
                                 </p>

--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -943,12 +943,26 @@ class Invoice_Generator {
                 );
             }
 
+            if (!function_exists('WP_Filesystem')) {
+                require_once ABSPATH . 'wp-admin/includes/file.php';
+            }
+
+            global $wp_filesystem;
+
+            if (!WP_Filesystem()) {
+                wp_die(
+                    esc_html__('Filesystem unavailable. Please try again later.', 'b2brouter-woocommerce'),
+                    esc_html__('Error', 'b2brouter-woocommerce'),
+                    array('response' => 500)
+                );
+            }
+
             // Check if PDF exists locally
             $pdf_path = $order->get_meta('_b2brouter_invoice_pdf_path');
 
             if (!empty($pdf_path) && file_exists($pdf_path)) {
                 // Use cached PDF
-                $pdf_data = file_get_contents($pdf_path);
+                $pdf_data = $wp_filesystem->get_contents($pdf_path);
                 $filename = basename($pdf_path);
             } else {
                 // Download and save PDF (this will cache it)
@@ -963,8 +977,16 @@ class Invoice_Generator {
                 }
 
                 // Read the saved PDF file
-                $pdf_data = file_get_contents($save_result['file_path']);
+                $pdf_data = $wp_filesystem->get_contents($save_result['file_path']);
                 $filename = basename($save_result['file_path']);
+            }
+
+            if ($pdf_data === false) {
+                wp_die(
+                    esc_html__('Failed to read invoice PDF.', 'b2brouter-woocommerce'),
+                    esc_html__('Error', 'b2brouter-woocommerce'),
+                    array('response' => 500)
+                );
             }
 
             // Clear any previous output
@@ -1215,12 +1237,6 @@ class Invoice_Generator {
             return array('deleted' => 0, 'errors' => 0);
         }
 
-        $pdf_files = glob($storage_path . '/*.pdf');
-
-        if (empty($pdf_files)) {
-            return array('deleted' => 0, 'errors' => 0);
-        }
-
         if (!function_exists('WP_Filesystem')) {
             require_once ABSPATH . 'wp-admin/includes/file.php';
         }
@@ -1232,10 +1248,21 @@ class Invoice_Generator {
             return array('deleted' => 0, 'errors' => 0);
         }
 
+        $entries = $wp_filesystem->dirlist($storage_path);
+
+        if (empty($entries)) {
+            return array('deleted' => 0, 'errors' => 0);
+        }
+
         $cutoff_time = time() - ($days * DAY_IN_SECONDS);
 
-        foreach ($pdf_files as $file) {
-            $file_time = filemtime($file);
+        foreach ($entries as $entry) {
+            if ($entry['type'] !== 'f' || substr($entry['name'], -4) !== '.pdf') {
+                continue;
+            }
+
+            $file = $storage_path . '/' . $entry['name'];
+            $file_time = (int) $entry['lastmodunix'];
 
             if ($file_time && $file_time < $cutoff_time) {
                 if ($wp_filesystem->delete($file)) {

--- a/includes/Uninstaller.php
+++ b/includes/Uninstaller.php
@@ -286,8 +286,12 @@ class Uninstaller {
      * @return void
      */
     protected function remove_directory($path) {
+        // @ suppresses PHP warnings at the syscall boundary; failures are
+        // surfaced through Logger::warning so leaked PDFs are visible in
+        // WooCommerce logs instead of silently dropped.
         $entries = @scandir($path);
         if ($entries === false) {
+            Logger::warning('B2Brouter Uninstall: scandir() failed for ' . $path);
             return;
         }
 
@@ -300,11 +304,15 @@ class Uninstaller {
             if (is_dir($full) && !is_link($full)) {
                 $this->remove_directory($full);
             } else {
-                @unlink($full);
+                if (!@unlink($full)) {
+                    Logger::warning('B2Brouter Uninstall: failed to delete ' . $full);
+                }
             }
         }
 
-        @rmdir($path);
+        if (!@rmdir($path)) {
+            Logger::warning('B2Brouter Uninstall: failed to remove directory ' . $path);
+        }
     }
 
     /**

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -433,4 +433,81 @@ class AdminTest extends TestCase {
         $this->assertCount(1, $params);
         $this->assertEquals('hook', $params[0]->getName());
     }
+
+    // ========== PDF Storage Stats (Phase: WP_Filesystem migration) ==========
+
+    public function test_get_pdf_storage_stats_returns_null_when_directory_missing() {
+        $this->mock_settings->method('get_pdf_storage_path')
+                            ->willReturn('/nonexistent/path-' . uniqid());
+
+        $this->assertNull($this->admin->get_pdf_storage_stats());
+    }
+
+    public function test_get_pdf_storage_stats_returns_zero_for_empty_directory() {
+        $temp_dir = sys_get_temp_dir() . '/b2brouter-stats-empty-' . uniqid();
+        mkdir($temp_dir);
+
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($temp_dir);
+
+        $stats = $this->admin->get_pdf_storage_stats();
+
+        $this->assertSame(array('count' => 0, 'total_size' => 0), $stats);
+
+        rmdir($temp_dir);
+    }
+
+    public function test_get_pdf_storage_stats_counts_pdfs_and_sums_sizes() {
+        $temp_dir = sys_get_temp_dir() . '/b2brouter-stats-' . uniqid();
+        mkdir($temp_dir);
+
+        file_put_contents($temp_dir . '/a.pdf', str_repeat('A', 100));
+        file_put_contents($temp_dir . '/b.pdf', str_repeat('B', 250));
+
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($temp_dir);
+
+        $stats = $this->admin->get_pdf_storage_stats();
+
+        $this->assertSame(2, $stats['count']);
+        $this->assertSame(350, $stats['total_size']);
+
+        @unlink($temp_dir . '/a.pdf');
+        @unlink($temp_dir . '/b.pdf');
+        rmdir($temp_dir);
+    }
+
+    public function test_get_pdf_storage_stats_ignores_non_pdf_files() {
+        $temp_dir = sys_get_temp_dir() . '/b2brouter-stats-mixed-' . uniqid();
+        mkdir($temp_dir);
+
+        file_put_contents($temp_dir . '/invoice.pdf', str_repeat('X', 100));
+        file_put_contents($temp_dir . '/notes.txt', str_repeat('Y', 999));
+        file_put_contents($temp_dir . '/.htaccess', 'deny from all');
+
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($temp_dir);
+
+        $stats = $this->admin->get_pdf_storage_stats();
+
+        $this->assertSame(1, $stats['count']);
+        $this->assertSame(100, $stats['total_size']);
+
+        @unlink($temp_dir . '/invoice.pdf');
+        @unlink($temp_dir . '/notes.txt');
+        @unlink($temp_dir . '/.htaccess');
+        rmdir($temp_dir);
+    }
+
+    public function test_get_pdf_storage_stats_returns_null_when_filesystem_init_fails() {
+        $temp_dir = sys_get_temp_dir() . '/b2brouter-stats-fsfail-' . uniqid();
+        mkdir($temp_dir);
+
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($temp_dir);
+
+        $GLOBALS['wp_filesystem_init_failure'] = true;
+        try {
+            $this->assertNull($this->admin->get_pdf_storage_stats());
+        } finally {
+            unset($GLOBALS['wp_filesystem_init_failure']);
+            rmdir($temp_dir);
+        }
+    }
 }

--- a/tests/InvoiceGeneratorTest.php
+++ b/tests/InvoiceGeneratorTest.php
@@ -771,6 +771,49 @@ class InvoiceGeneratorTest extends TestCase {
     }
 
     /**
+     * Cleanup must delete files older than the cutoff and keep newer ones.
+     *
+     * Exercises the WP_Filesystem dirlist+delete path with real PDFs in a
+     * temp dir. The legacy implementation used glob()+filemtime(); the
+     * migrated implementation uses $wp_filesystem->dirlist() and reads
+     * the lastmodunix metadata directly.
+     *
+     * @return void
+     */
+    public function test_cleanup_old_pdfs_deletes_only_old_files() {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function prepare($query, ...$args) { return $query; }
+            public function get_col($query) { return array(); }
+        };
+
+        $temp_dir = sys_get_temp_dir() . '/b2brouter-cleanup-' . uniqid();
+        mkdir($temp_dir);
+
+        $old_file = $temp_dir . '/old-invoice.pdf';
+        $new_file = $temp_dir . '/new-invoice.pdf';
+        file_put_contents($old_file, '%PDF old');
+        file_put_contents($new_file, '%PDF new');
+        touch($old_file, time() - 100 * DAY_IN_SECONDS);
+        touch($new_file, time() - 5 * DAY_IN_SECONDS);
+
+        $this->mock_settings->method('get_pdf_storage_path')
+                           ->willReturn($temp_dir);
+
+        $result = $this->generator->cleanup_old_pdfs(90);
+
+        $this->assertEquals(1, $result['deleted']);
+        $this->assertEquals(0, $result['errors']);
+        $this->assertFileDoesNotExist($old_file);
+        $this->assertFileExists($new_file);
+
+        @unlink($new_file);
+        @rmdir($temp_dir);
+        $wpdb = null;
+    }
+
+    /**
      * Test cleanup_old_pdfs result structure
      *
      * @return void
@@ -965,6 +1008,41 @@ class InvoiceGeneratorTest extends TestCase {
         $this->generator->stream_invoice_pdf(403, false);
 
         unset($wc_mock_orders[403]);
+    }
+
+    /**
+     * Stream cached PDF must read through WP_Filesystem, not file_get_contents.
+     *
+     * When $wp_filesystem->get_contents() returns false (fail-injected), the
+     * method must wp_die instead of echoing an empty body. The legacy code
+     * path uses file_get_contents directly, so it would echo+exit and never
+     * reach wp_die — runInSeparateProcess isolates the exit.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_stream_invoice_pdf_reads_cached_pdf_via_filesystem() {
+        global $wc_mock_orders;
+
+        $temp_pdf = sys_get_temp_dir() . '/b2brouter-stream-' . uniqid() . '.pdf';
+        file_put_contents($temp_pdf, '%PDF-1.5 fake');
+
+        $order = new WC_Order(450);
+        $order->add_meta_data('_b2brouter_invoice_id', 'inv-450');
+        $order->add_meta_data('_b2brouter_invoice_pdf_path', $temp_pdf);
+        $wc_mock_orders[450] = $order;
+
+        $GLOBALS['wp_filesystem_fail_methods'] = array('get_contents');
+
+        try {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('wp_die called');
+            $this->generator->stream_invoice_pdf(450);
+        } finally {
+            unset($GLOBALS['wp_filesystem_fail_methods']);
+            @unlink($temp_pdf);
+            unset($wc_mock_orders[450]);
+        }
     }
 
     // ========== PDF Delete Tests (Phase 5) ==========

--- a/tests/UninstallerTest.php
+++ b/tests/UninstallerTest.php
@@ -154,6 +154,35 @@ class UninstallerTest extends TestCase {
         $this->assertTrue(true); // no exception
     }
 
+    public function test_remove_directory_logs_warning_when_unlink_fails(): void {
+        if (DIRECTORY_SEPARATOR === '\\' || (function_exists('posix_geteuid') && posix_geteuid() === 0)) {
+            $this->markTestSkipped('Filesystem permission test requires non-root POSIX');
+        }
+
+        mkdir($this->tmp_pdf_dir, 0777, true);
+        $blocked_file = $this->tmp_pdf_dir . '/blocked.pdf';
+        file_put_contents($blocked_file, 'cannot delete me');
+        chmod($this->tmp_pdf_dir, 0555); // r-x: prevents unlink/rmdir inside
+
+        update_option('b2brouter_pdf_storage_path', $this->tmp_pdf_dir);
+        $GLOBALS['wc_logger_calls'] = array();
+
+        try {
+            $this->uninstaller->delete_pdf_directory();
+        } finally {
+            chmod($this->tmp_pdf_dir, 0777);
+            @unlink($blocked_file);
+            @rmdir($this->tmp_pdf_dir);
+        }
+
+        $this->assertArrayHasKey('warning', $GLOBALS['wc_logger_calls']);
+        $messages = array_column($GLOBALS['wc_logger_calls']['warning'], 'message');
+        $matched = array_filter($messages, function ($m) use ($blocked_file) {
+            return strpos($m, $blocked_file) !== false;
+        });
+        $this->assertNotEmpty($matched, 'expected a warning mentioning the blocked file');
+    }
+
     public function test_delete_options_and_transients_clears_plugin_options(): void {
         global $wp_options, $wp_transients;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -213,12 +213,17 @@ if (!function_exists('error_log')) {
     }
 }
 
+// Recording logger: tests can inspect $GLOBALS['wc_logger_calls'] to assert
+// which levels were logged with which messages. Reset between tests as needed.
+global $wc_logger_calls;
+$wc_logger_calls = array();
+
 if (!function_exists('wc_get_logger')) {
     /**
      * Mock wc_get_logger function
      *
-     * Returns a no-op logger with error/warning/info/log methods so calls
-     * from B2Brouter\WooCommerce\Logger don't fail under test.
+     * Returns a recording logger that captures every call into
+     * $GLOBALS['wc_logger_calls'] keyed by level.
      *
      * @return object Logger stub
      */
@@ -226,15 +231,27 @@ if (!function_exists('wc_get_logger')) {
         static $logger = null;
         if ($logger === null) {
             $logger = new class {
-                public function log($level, $message, $context = array()) {}
-                public function error($message, $context = array()) {}
-                public function warning($message, $context = array()) {}
-                public function info($message, $context = array()) {}
-                public function debug($message, $context = array()) {}
-                public function notice($message, $context = array()) {}
-                public function critical($message, $context = array()) {}
-                public function alert($message, $context = array()) {}
-                public function emergency($message, $context = array()) {}
+                private function record($level, $message, $context) {
+                    if (!isset($GLOBALS['wc_logger_calls'])) {
+                        $GLOBALS['wc_logger_calls'] = array();
+                    }
+                    if (!isset($GLOBALS['wc_logger_calls'][$level])) {
+                        $GLOBALS['wc_logger_calls'][$level] = array();
+                    }
+                    $GLOBALS['wc_logger_calls'][$level][] = array(
+                        'message' => $message,
+                        'context' => $context,
+                    );
+                }
+                public function log($level, $message, $context = array()) { $this->record($level, $message, $context); }
+                public function error($message, $context = array()) { $this->record('error', $message, $context); }
+                public function warning($message, $context = array()) { $this->record('warning', $message, $context); }
+                public function info($message, $context = array()) { $this->record('info', $message, $context); }
+                public function debug($message, $context = array()) { $this->record('debug', $message, $context); }
+                public function notice($message, $context = array()) { $this->record('notice', $message, $context); }
+                public function critical($message, $context = array()) { $this->record('critical', $message, $context); }
+                public function alert($message, $context = array()) { $this->record('alert', $message, $context); }
+                public function emergency($message, $context = array()) { $this->record('emergency', $message, $context); }
             };
         }
         return $logger;
@@ -1814,5 +1831,158 @@ if (!function_exists('size_format')) {
             return number_format($bytes / 1024, $decimals) . ' KB';
         }
         return $bytes . ' B';
+    }
+}
+
+// WP Filesystem mock: passthrough to real PHP filesystem.
+// Mirrors WP_Filesystem_Direct so migrated code runs end-to-end against
+// real temp directories. Tests inject failures via globals:
+//   $GLOBALS['wp_filesystem_init_failure'] = true   // WP_Filesystem() returns false
+//   $GLOBALS['wp_filesystem_fail_methods'] = ['delete', 'get_contents', ...]
+
+if (!defined('FS_CHMOD_FILE')) {
+    define('FS_CHMOD_FILE', 0644);
+}
+if (!defined('FS_CHMOD_DIR')) {
+    define('FS_CHMOD_DIR', 0755);
+}
+
+if (!class_exists('B2BRouter_Test_WP_Filesystem_Stub')) {
+    class B2BRouter_Test_WP_Filesystem_Stub {
+        private function should_fail($method) {
+            return !empty($GLOBALS['wp_filesystem_fail_methods'])
+                && in_array($method, (array) $GLOBALS['wp_filesystem_fail_methods'], true);
+        }
+
+        public function get_contents($file) {
+            if ($this->should_fail('get_contents')) {
+                return false;
+            }
+            $contents = @file_get_contents($file);
+            return $contents === false ? false : $contents;
+        }
+
+        public function put_contents($file, $contents, $mode = false) {
+            if ($this->should_fail('put_contents')) {
+                return false;
+            }
+            $bytes = @file_put_contents($file, $contents);
+            if ($bytes === false) {
+                return false;
+            }
+            if ($mode !== false) {
+                @chmod($file, $mode);
+            }
+            return true;
+        }
+
+        public function delete($file, $recursive = false, $type = false) {
+            if ($this->should_fail('delete')) {
+                return false;
+            }
+            if (!file_exists($file) && !is_link($file)) {
+                return false;
+            }
+            if (is_dir($file) && !is_link($file)) {
+                if ($recursive) {
+                    $entries = @scandir($file);
+                    if ($entries !== false) {
+                        foreach ($entries as $entry) {
+                            if ($entry === '.' || $entry === '..') {
+                                continue;
+                            }
+                            $this->delete($file . '/' . $entry, true);
+                        }
+                    }
+                }
+                return @rmdir($file);
+            }
+            return @unlink($file);
+        }
+
+        public function exists($file) {
+            return file_exists($file);
+        }
+
+        public function is_dir($path) {
+            return is_dir($path);
+        }
+
+        public function is_file($file) {
+            return is_file($file);
+        }
+
+        public function mkdir($path, $chmod = false, $chown = false, $chgrp = false) {
+            if ($this->should_fail('mkdir')) {
+                return false;
+            }
+            if (is_dir($path)) {
+                return true;
+            }
+            $mode = $chmod === false ? FS_CHMOD_DIR : $chmod;
+            return @mkdir($path, $mode, true);
+        }
+
+        public function chmod($file, $mode = false, $recursive = false) {
+            if ($mode === false) {
+                $mode = is_file($file) ? FS_CHMOD_FILE : FS_CHMOD_DIR;
+            }
+            return @chmod($file, $mode);
+        }
+
+        public function dirlist($path, $include_hidden = true, $recursive = false) {
+            if ($this->should_fail('dirlist')) {
+                return false;
+            }
+            if (!is_dir($path)) {
+                return false;
+            }
+            $entries = @scandir($path);
+            if ($entries === false) {
+                return false;
+            }
+            $result = array();
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                if (!$include_hidden && $entry[0] === '.') {
+                    continue;
+                }
+                $full = $path . '/' . $entry;
+                $is_dir = is_dir($full);
+                $info = array(
+                    'name'        => $entry,
+                    'perms'       => '',
+                    'permsn'      => 0,
+                    'number'      => false,
+                    'owner'       => '',
+                    'group'       => '',
+                    'size'        => $is_dir ? 0 : (int) @filesize($full),
+                    'lastmodunix' => (int) @filemtime($full),
+                    'lastmod'     => '',
+                    'time'        => '',
+                    'type'        => $is_dir ? 'd' : 'f',
+                );
+                if ($is_dir && $recursive) {
+                    $info['files'] = $this->dirlist($full, $include_hidden, true);
+                }
+                $result[$entry] = $info;
+            }
+            return $result;
+        }
+    }
+}
+
+if (!function_exists('WP_Filesystem')) {
+    function WP_Filesystem($args = false, $context = false, $allow_relaxed_file_ownership = false) {
+        if (!empty($GLOBALS['wp_filesystem_init_failure'])) {
+            return false;
+        }
+        global $wp_filesystem;
+        if (!($wp_filesystem instanceof B2BRouter_Test_WP_Filesystem_Stub)) {
+            $wp_filesystem = new B2BRouter_Test_WP_Filesystem_Stub();
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Migrates the remaining direct filesystem calls to WP_Filesystem ahead of the wp.org submission, so the changelog's "Filesystem API migration" claim is fully accurate.

* Invoice_Generator::stream_invoice_pdf reads cached and freshly-saved PDFs through $wp_filesystem->get_contents(). Adds a 500 wp_die when the filesystem is unavailable or the read returns false, so a corrupt cache no longer streams an empty 200 response.
* Invoice_Generator::cleanup_old_pdfs replaces glob() + filemtime() with $wp_filesystem->dirlist(), reading the modification timestamp directly from the entry metadata.
* Admin settings page extracts the PDF storage summary into a public get_pdf_storage_stats() method that uses dirlist() and reads size from the entry metadata, dropping the per-file filesize() loop. Returns null when the directory is missing or WP_Filesystem cannot be initialised, falling back to the existing placeholder UI.
* Uninstaller::remove_directory now logs scandir/unlink/rmdir failures via Logger::warning so leaked directories surface in WooCommerce logs instead of silence. The @ stays at the syscall boundary to suppress PHP-level warnings; the issue's stated goal — WC-log visibility — is met by capturing return values and logging.

Closes #36.