### PR TITLE
Move bulk invoice generation to Action Scheduler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to B2Brouter for WooCommerce will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Bulk Invoice Generation**: The "Generate B2Brouter Invoices" bulk action now enqueues background jobs via Action Scheduler instead of generating invoices synchronously. Eliminates 504 timeouts on large selections (worst case was ~12 minutes for 50 orders with auto-save PDF). Orders that already have an invoice are pre-filtered and counted as skipped. Progress and per-action logs are visible under **WooCommerce → Status → Scheduled Actions** (group `b2brouter`) (closes #37)
+
 ## [0.9.4] - 2026-04-23
 
 Final pre-release before 1.0. Focused on stability, operational polish, and preparing the plugin for distribution via the WordPress.org plugin directory and the WooCommerce Marketplace.

--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ Get instant invoice status updates instead of waiting for hourly checks. This 5-
 - **Need to test on localhost?**
   - See [docs/LOCAL_DEVELOPMENT_SETUP.md](docs/LOCAL_DEVELOPMENT_SETUP.md) for detailed local testing instructions
 
+- **Bulk invoice generation stuck "queued"?**
+  - The "Generate B2Brouter Invoices" bulk action enqueues background jobs via Action Scheduler. Jobs are processed by WP-Cron. If your store has WP-Cron disabled (`define('DISABLE_WP_CRON', true)` without a system cron replacement), queued jobs will sit forever. Inspect and run pending actions under **WooCommerce → Status → Scheduled Actions** (filter by group `b2brouter`).
+
 **Security Notes:**
 
 - All webhook requests are cryptographically signed with HMAC-SHA256

--- a/includes/Order_Handler.php
+++ b/includes/Order_Handler.php
@@ -652,11 +652,18 @@ class Order_Handler {
                 continue;
             }
 
-            as_enqueue_async_action(
-                'b2brouter_bulk_generate_invoice',
-                array('order_id' => (int) $post_id),
-                'b2brouter'
-            );
+            $args = array('order_id' => (int) $post_id);
+
+            // Dedupe: if an action for this order is already pending (e.g. the
+            // merchant re-submitted the bulk form before the queue drained),
+            // don't enqueue a second copy. Still count it as queued so the
+            // notice reflects that the work is in flight.
+            if (as_has_scheduled_action('b2brouter_bulk_generate_invoice', $args, 'b2brouter')) {
+                $queued_count++;
+                continue;
+            }
+
+            as_enqueue_async_action('b2brouter_bulk_generate_invoice', $args, 'b2brouter');
             $queued_count++;
         }
 
@@ -676,7 +683,12 @@ class Order_Handler {
      * @return void
      */
     public function process_queued_invoice($order_id) {
-        $this->invoice_generator->generate_invoice((int) $order_id);
+        $result = $this->invoice_generator->generate_invoice((int) $order_id);
+        if (empty($result['success'])) {
+            throw new \RuntimeException(
+                isset($result['message']) ? $result['message'] : 'Invoice generation failed'
+            );
+        }
     }
 
     /**

--- a/includes/Order_Handler.php
+++ b/includes/Order_Handler.php
@@ -75,6 +75,9 @@ class Order_Handler {
 
         add_action('admin_notices', array($this, 'bulk_action_notices'));
 
+        // Background worker for bulk-queued invoice generation (Action Scheduler)
+        add_action('b2brouter_bulk_generate_invoice', array($this, 'process_queued_invoice'), 10, 1);
+
         // Email PDF attachments
         add_filter('woocommerce_email_attachments', array($this, 'attach_pdf_to_email'), 10, 3);
 
@@ -626,39 +629,54 @@ class Order_Handler {
             return $redirect_to;
         }
 
-        $success_count = 0;
-        $error_count = 0;
+        $queued_count = 0;
         $skipped_count = 0;
 
         foreach ($post_ids as $post_id) {
             $order = wc_get_order($post_id);
 
             if (!$order) {
-                $error_count++;
                 continue;
             }
 
-            // Only completed orders are eligible for invoice generation
+            // Only completed orders are eligible for invoice generation.
             if ($order->get_status() !== 'completed') {
                 $skipped_count++;
                 continue;
             }
 
-            $result = $this->invoice_generator->generate_invoice($post_id);
-            if ($result['success']) {
-                $success_count++;
-            } else {
-                $error_count++;
+            // Already invoiced orders are skipped before enqueueing so they
+            // don't surface as run-time failures in Scheduled Actions.
+            if ($this->invoice_generator->has_invoice($post_id)) {
+                $skipped_count++;
+                continue;
             }
+
+            as_enqueue_async_action(
+                'b2brouter_bulk_generate_invoice',
+                array('order_id' => (int) $post_id),
+                'b2brouter'
+            );
+            $queued_count++;
         }
 
         $redirect_to = add_query_arg(array(
-            'b2brouter_bulk_success' => $success_count,
-            'b2brouter_bulk_error' => $error_count,
+            'b2brouter_bulk_queued' => $queued_count,
             'b2brouter_bulk_skipped' => $skipped_count,
         ), $redirect_to);
 
         return $redirect_to;
+    }
+
+    /**
+     * Process a single queued invoice generation job (Action Scheduler worker).
+     *
+     * @since 1.0.0
+     * @param int $order_id The WooCommerce order ID
+     * @return void
+     */
+    public function process_queued_invoice($order_id) {
+        $this->invoice_generator->generate_invoice((int) $order_id);
     }
 
     /**
@@ -668,40 +686,31 @@ class Order_Handler {
      * @return void
      */
     public function bulk_action_notices() {
-        if (!isset($_GET['b2brouter_bulk_success'])
-            && !isset($_GET['b2brouter_bulk_error'])
+        if (!isset($_GET['b2brouter_bulk_queued'])
             && !isset($_GET['b2brouter_bulk_skipped'])) {
             return;
         }
 
-        $success_count = isset($_GET['b2brouter_bulk_success']) ? intval($_GET['b2brouter_bulk_success']) : 0;
-        $error_count = isset($_GET['b2brouter_bulk_error']) ? intval($_GET['b2brouter_bulk_error']) : 0;
+        $queued_count = isset($_GET['b2brouter_bulk_queued']) ? intval($_GET['b2brouter_bulk_queued']) : 0;
         $skipped_count = isset($_GET['b2brouter_bulk_skipped']) ? intval($_GET['b2brouter_bulk_skipped']) : 0;
 
-        if ($success_count > 0) {
-            echo '<div class="notice notice-success is-dismissible"><p>';
-            echo sprintf(
-                _n(
-                    '%d invoice generated successfully.',
-                    '%d invoices generated successfully.',
-                    $success_count,
-                    'b2brouter-woocommerce'
-                ),
-                $success_count
-            );
-            echo '</p></div>';
-        }
+        if ($queued_count > 0) {
+            // Deep link to the Action Scheduler UI, filtered to our hook so
+            // merchants can watch progress and inspect per-action logs. AS does
+            // not honor a ?group= filter param; the `s` (search) param is what
+            // narrows the list to a hook name.
+            $scheduled_actions_url = admin_url('admin.php?page=wc-status&tab=action-scheduler&s=b2brouter_bulk_generate_invoice');
 
-        if ($error_count > 0) {
-            echo '<div class="notice notice-error is-dismissible"><p>';
+            echo '<div class="notice notice-info is-dismissible"><p>';
             echo sprintf(
                 _n(
-                    '%d invoice failed to generate.',
-                    '%d invoices failed to generate.',
-                    $error_count,
+                    '%1$d invoice queued for background processing. <a href="%2$s">View Scheduled Actions</a>.',
+                    '%1$d invoices queued for background processing. <a href="%2$s">View Scheduled Actions</a>.',
+                    $queued_count,
                     'b2brouter-woocommerce'
                 ),
-                $error_count
+                $queued_count,
+                esc_url($scheduled_actions_url)
             );
             echo '</p></div>';
         }
@@ -710,8 +719,8 @@ class Order_Handler {
             echo '<div class="notice notice-warning is-dismissible"><p>';
             echo sprintf(
                 _n(
-                    '%d order was skipped because it is not in the completed status. Only completed orders can be invoiced from the bulk action.',
-                    '%d orders were skipped because they are not in the completed status. Only completed orders can be invoiced from the bulk action.',
+                    '%d order was skipped because it is not completed or already has an invoice.',
+                    '%d orders were skipped because they are not completed or already have invoices.',
                     $skipped_count,
                     'b2brouter-woocommerce'
                 ),

--- a/tests/OrderHandlerTest.php
+++ b/tests/OrderHandlerTest.php
@@ -374,12 +374,14 @@ class OrderHandlerTest extends TestCase {
     }
 
     /**
-     * Test handle_bulk_action processes orders
+     * Test handle_bulk_action enqueues an async action per eligible order
+     * and never calls the generator inline.
      *
      * @return void
      */
-    public function test_handle_bulk_action_generates_invoices() {
-        global $wc_mock_orders;
+    public function test_handle_bulk_action_enqueues_eligible_orders() {
+        global $wc_mock_orders, $as_async_actions;
+        $as_async_actions = array();
 
         foreach (array(100, 101, 102) as $id) {
             $order = new WC_Order($id);
@@ -387,14 +389,25 @@ class OrderHandlerTest extends TestCase {
             $wc_mock_orders[$id] = $order;
         }
 
-        $this->mock_invoice_generator->method('generate_invoice')
-                                    ->willReturn(array('success' => true));
+        // has_invoice() short-circuit must run; none of these have an invoice.
+        $this->mock_invoice_generator->method('has_invoice')->willReturn(false);
+
+        // The generator must NOT be called synchronously from the bulk handler.
+        $this->mock_invoice_generator->expects($this->never())
+                                    ->method('generate_invoice');
 
         $redirect_to = 'http://example.com/wp-admin/edit.php';
         $result = $this->handler->handle_bulk_action($redirect_to, 'b2brouter_generate_invoices', array(100, 101, 102));
 
-        $this->assertStringContainsString('b2brouter_bulk_success=3', $result);
-        $this->assertStringContainsString('b2brouter_bulk_error=0', $result);
+        $this->assertCount(3, $as_async_actions);
+        $this->assertSame('b2brouter_bulk_generate_invoice', $as_async_actions[0]['hook']);
+        $this->assertSame('b2brouter', $as_async_actions[0]['group']);
+        $this->assertSame(array(100, 101, 102), array_map(
+            function ($entry) { return $entry['args']['order_id']; },
+            $as_async_actions
+        ));
+
+        $this->assertStringContainsString('b2brouter_bulk_queued=3', $result);
         $this->assertStringContainsString('b2brouter_bulk_skipped=0', $result);
 
         foreach (array(100, 101, 102) as $id) {
@@ -403,44 +416,13 @@ class OrderHandlerTest extends TestCase {
     }
 
     /**
-     * Test handle_bulk_action counts errors
-     *
-     * @return void
-     */
-    public function test_handle_bulk_action_counts_errors() {
-        global $wc_mock_orders;
-
-        foreach (array(100, 101, 102) as $id) {
-            $order = new WC_Order($id);
-            $order->set_status('completed');
-            $wc_mock_orders[$id] = $order;
-        }
-
-        $this->mock_invoice_generator->method('generate_invoice')
-                                    ->willReturnOnConsecutiveCalls(
-                                        array('success' => true),
-                                        array('success' => false),
-                                        array('success' => true)
-                                    );
-
-        $redirect_to = 'http://example.com/wp-admin/edit.php';
-        $result = $this->handler->handle_bulk_action($redirect_to, 'b2brouter_generate_invoices', array(100, 101, 102));
-
-        $this->assertStringContainsString('b2brouter_bulk_success=2', $result);
-        $this->assertStringContainsString('b2brouter_bulk_error=1', $result);
-
-        foreach (array(100, 101, 102) as $id) {
-            unset($wc_mock_orders[$id]);
-        }
-    }
-
-    /**
-     * Test handle_bulk_action skips non-completed orders and does not invoice them
+     * Test handle_bulk_action skips non-completed orders and does not enqueue them.
      *
      * @return void
      */
     public function test_handle_bulk_action_skips_non_completed_orders() {
-        global $wc_mock_orders;
+        global $wc_mock_orders, $as_async_actions;
+        $as_async_actions = array();
 
         $completed = new WC_Order(200);
         $completed->set_status('completed');
@@ -454,36 +436,69 @@ class OrderHandlerTest extends TestCase {
         $pending->set_status('pending');
         $wc_mock_orders[202] = $pending;
 
-        // Only the completed order should reach the generator
-        $this->mock_invoice_generator->expects($this->once())
-                                    ->method('generate_invoice')
-                                    ->with(200)
-                                    ->willReturn(array('success' => true));
+        $this->mock_invoice_generator->method('has_invoice')->willReturn(false);
+        $this->mock_invoice_generator->expects($this->never())->method('generate_invoice');
 
         $redirect_to = 'http://example.com/wp-admin/edit.php';
         $result = $this->handler->handle_bulk_action($redirect_to, 'b2brouter_generate_invoices', array(200, 201, 202));
 
-        $this->assertStringContainsString('b2brouter_bulk_success=1', $result);
-        $this->assertStringContainsString('b2brouter_bulk_error=0', $result);
+        $this->assertCount(1, $as_async_actions);
+        $this->assertSame(200, $as_async_actions[0]['args']['order_id']);
+
+        $this->assertStringContainsString('b2brouter_bulk_queued=1', $result);
         $this->assertStringContainsString('b2brouter_bulk_skipped=2', $result);
 
         unset($wc_mock_orders[200], $wc_mock_orders[201], $wc_mock_orders[202]);
     }
 
     /**
-     * Test handle_bulk_action counts missing orders as errors
+     * Test handle_bulk_action skips orders that already have an invoice.
      *
      * @return void
      */
-    public function test_handle_bulk_action_counts_missing_orders_as_errors() {
-        $this->mock_invoice_generator->expects($this->never())
-                                    ->method('generate_invoice');
+    public function test_handle_bulk_action_skips_already_invoiced_orders() {
+        global $wc_mock_orders, $as_async_actions;
+        $as_async_actions = array();
+
+        foreach (array(300, 301) as $id) {
+            $order = new WC_Order($id);
+            $order->set_status('completed');
+            $wc_mock_orders[$id] = $order;
+        }
+
+        // 300 already invoiced, 301 not.
+        $this->mock_invoice_generator->method('has_invoice')
+            ->willReturnMap(array(
+                array(300, true),
+                array(301, false),
+            ));
+
+        $redirect_to = 'http://example.com/wp-admin/edit.php';
+        $result = $this->handler->handle_bulk_action($redirect_to, 'b2brouter_generate_invoices', array(300, 301));
+
+        $this->assertCount(1, $as_async_actions);
+        $this->assertSame(301, $as_async_actions[0]['args']['order_id']);
+
+        $this->assertStringContainsString('b2brouter_bulk_queued=1', $result);
+        $this->assertStringContainsString('b2brouter_bulk_skipped=1', $result);
+
+        unset($wc_mock_orders[300], $wc_mock_orders[301]);
+    }
+
+    /**
+     * Test handle_bulk_action does not enqueue when wc_get_order returns null.
+     *
+     * @return void
+     */
+    public function test_handle_bulk_action_does_not_enqueue_missing_orders() {
+        global $as_async_actions;
+        $as_async_actions = array();
 
         $redirect_to = 'http://example.com/wp-admin/edit.php';
         $result = $this->handler->handle_bulk_action($redirect_to, 'b2brouter_generate_invoices', array(9999));
 
-        $this->assertStringContainsString('b2brouter_bulk_error=1', $result);
-        $this->assertStringContainsString('b2brouter_bulk_success=0', $result);
+        $this->assertCount(0, $as_async_actions);
+        $this->assertStringContainsString('b2brouter_bulk_queued=0', $result);
     }
 
     /**
@@ -499,56 +514,67 @@ class OrderHandlerTest extends TestCase {
     }
 
     /**
-     * Test bulk_action_notices shows success
+     * Test process_queued_invoice delegates to the generator with the order id.
      *
      * @return void
      */
-    public function test_bulk_action_notices_shows_success_message() {
-        $_GET['b2brouter_bulk_success'] = '5';
+    public function test_process_queued_invoice_delegates_to_generator() {
+        $this->mock_invoice_generator->expects($this->once())
+                                    ->method('generate_invoice')
+                                    ->with(123)
+                                    ->willReturn(array('success' => true));
 
-        ob_start();
-        $this->handler->bulk_action_notices();
-        $output = ob_get_clean();
-
-        $this->assertStringContainsString('notice-success', $output);
-        $this->assertStringContainsString('5 invoices generated successfully', $output);
-
-        unset($_GET['b2brouter_bulk_success']);
+        $this->handler->process_queued_invoice(123);
     }
 
     /**
-     * Test bulk_action_notices shows error
+     * Test process_queued_invoice action hook is registered.
      *
      * @return void
      */
-    public function test_bulk_action_notices_shows_error_message() {
-        $_GET['b2brouter_bulk_error'] = '3';
+    public function test_process_queued_invoice_hook_is_registered() {
+        global $wp_actions;
 
-        ob_start();
-        $this->handler->bulk_action_notices();
-        $output = ob_get_clean();
-
-        $this->assertStringContainsString('notice-error', $output);
-        $this->assertStringContainsString('3 invoices failed to generate', $output);
-
-        unset($_GET['b2brouter_bulk_error']);
+        $this->assertArrayHasKey('b2brouter_bulk_generate_invoice', $wp_actions);
     }
 
     /**
-     * Test bulk_action_notices singular form
+     * Test bulk_action_notices shows the queued info message.
      *
      * @return void
      */
-    public function test_bulk_action_notices_uses_singular_for_one() {
-        $_GET['b2brouter_bulk_success'] = '1';
+    public function test_bulk_action_notices_shows_queued_message() {
+        $_GET['b2brouter_bulk_queued'] = '5';
 
         ob_start();
         $this->handler->bulk_action_notices();
         $output = ob_get_clean();
 
-        $this->assertStringContainsString('1 invoice generated successfully', $output);
+        $this->assertStringContainsString('notice-info', $output);
+        $this->assertStringContainsString('5 invoices queued', $output);
+        // Deep link to AS UI: AS reads `s` (search) — not `group` — so we
+        // narrow by hook name, which uniquely identifies our actions.
+        $this->assertStringContainsString('page=wc-status', $output);
+        $this->assertStringContainsString('s=b2brouter_bulk_generate_invoice', $output);
 
-        unset($_GET['b2brouter_bulk_success']);
+        unset($_GET['b2brouter_bulk_queued']);
+    }
+
+    /**
+     * Test bulk_action_notices uses singular for one queued.
+     *
+     * @return void
+     */
+    public function test_bulk_action_notices_uses_singular_for_one_queued() {
+        $_GET['b2brouter_bulk_queued'] = '1';
+
+        ob_start();
+        $this->handler->bulk_action_notices();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 invoice queued', $output);
+
+        unset($_GET['b2brouter_bulk_queued']);
     }
 
     /**
@@ -578,7 +604,7 @@ class OrderHandlerTest extends TestCase {
 
         $this->assertStringContainsString('notice-warning', $output);
         $this->assertStringContainsString('2 orders were skipped', $output);
-        $this->assertStringContainsString('completed status', $output);
+        $this->assertStringContainsString('not completed or already have invoices', $output);
 
         unset($_GET['b2brouter_bulk_skipped']);
     }

--- a/tests/OrderHandlerTest.php
+++ b/tests/OrderHandlerTest.php
@@ -486,6 +486,42 @@ class OrderHandlerTest extends TestCase {
     }
 
     /**
+     * Test handle_bulk_action does not enqueue a second copy when an action
+     * for the same order is already pending in the queue.
+     *
+     * @return void
+     */
+    public function test_handle_bulk_action_dedupes_already_queued_orders() {
+        global $wc_mock_orders, $as_async_actions;
+        $as_async_actions = array();
+
+        $order = new WC_Order(400);
+        $order->set_status('completed');
+        $wc_mock_orders[400] = $order;
+
+        $this->mock_invoice_generator->method('has_invoice')->willReturn(false);
+
+        // Simulate an earlier submission that already queued this order.
+        $as_async_actions[] = array(
+            'hook' => 'b2brouter_bulk_generate_invoice',
+            'args' => array('order_id' => 400),
+            'group' => 'b2brouter',
+        );
+
+        $redirect_to = 'http://example.com/wp-admin/edit.php';
+        $result = $this->handler->handle_bulk_action($redirect_to, 'b2brouter_generate_invoices', array(400));
+
+        // Still one row total — no duplicate was added.
+        $this->assertCount(1, $as_async_actions);
+
+        // Counted as queued so the notice reflects that the work is in flight.
+        $this->assertStringContainsString('b2brouter_bulk_queued=1', $result);
+        $this->assertStringContainsString('b2brouter_bulk_skipped=0', $result);
+
+        unset($wc_mock_orders[400]);
+    }
+
+    /**
      * Test handle_bulk_action does not enqueue when wc_get_order returns null.
      *
      * @return void
@@ -528,14 +564,59 @@ class OrderHandlerTest extends TestCase {
     }
 
     /**
-     * Test process_queued_invoice action hook is registered.
+     * Test process_queued_invoice throws when the generator reports failure,
+     * so Action Scheduler marks the action failed and logs the message.
      *
      * @return void
      */
-    public function test_process_queued_invoice_hook_is_registered() {
-        global $wp_actions;
+    public function test_process_queued_invoice_throws_on_generator_failure() {
+        $this->mock_invoice_generator->expects($this->once())
+                                    ->method('generate_invoice')
+                                    ->with(456)
+                                    ->willReturn(array(
+                                        'success' => false,
+                                        'message' => 'Account ID not configured',
+                                    ));
 
-        $this->assertArrayHasKey('b2brouter_bulk_generate_invoice', $wp_actions);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Account ID not configured');
+
+        $this->handler->process_queued_invoice(456);
+    }
+
+    /**
+     * Test process_queued_invoice falls back to a generic message when the
+     * generator omits one.
+     *
+     * @return void
+     */
+    public function test_process_queued_invoice_throws_with_fallback_message() {
+        $this->mock_invoice_generator->expects($this->once())
+                                    ->method('generate_invoice')
+                                    ->with(789)
+                                    ->willReturn(array('success' => false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invoice generation failed');
+
+        $this->handler->process_queued_invoice(789);
+    }
+
+    /**
+     * Test the worker is wired to the AS hook end-to-end: firing
+     * b2brouter_bulk_generate_invoice with an order_id reaches the generator.
+     * Stronger than asserting the hook key exists, since this also catches
+     * wrong callbacks, wrong priority, or accepted_args=0.
+     *
+     * @return void
+     */
+    public function test_process_queued_invoice_runs_when_hook_fires() {
+        $this->mock_invoice_generator->expects($this->once())
+                                    ->method('generate_invoice')
+                                    ->with(999)
+                                    ->willReturn(array('success' => true));
+
+        do_action('b2brouter_bulk_generate_invoice', 999);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -770,6 +770,31 @@ if (!function_exists('wp_schedule_single_event')) {
     }
 }
 
+// Global storage for Action Scheduler async actions enqueued by the plugin.
+// Tests inspect $GLOBALS['as_async_actions'] to assert what was queued.
+global $as_async_actions;
+$as_async_actions = array();
+
+if (!function_exists('as_enqueue_async_action')) {
+    /**
+     * Mock as_enqueue_async_action function (Action Scheduler)
+     *
+     * @param string $hook  Hook name
+     * @param array  $args  Arguments passed to the hook
+     * @param string $group Group name
+     * @return int Mock action ID
+     */
+    function as_enqueue_async_action($hook, $args = array(), $group = '') {
+        global $as_async_actions;
+        $as_async_actions[] = array(
+            'hook' => $hook,
+            'args' => $args,
+            'group' => $group,
+        );
+        return count($as_async_actions); // mock action ID
+    }
+}
+
 if (!function_exists('wp_upload_dir')) {
     /**
      * Mock wp_upload_dir function

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -795,6 +795,38 @@ if (!function_exists('as_enqueue_async_action')) {
     }
 }
 
+if (!function_exists('as_has_scheduled_action')) {
+    /**
+     * Mock as_has_scheduled_action — returns true if a matching pending
+     * action is found in $as_async_actions. Tests that need to simulate
+     * an already-queued action push entries directly into the global.
+     *
+     * @param string     $hook
+     * @param array|null $args
+     * @param string     $group
+     * @return bool
+     */
+    function as_has_scheduled_action($hook, $args = null, $group = '') {
+        global $as_async_actions;
+        if (empty($as_async_actions)) {
+            return false;
+        }
+        foreach ($as_async_actions as $entry) {
+            if ($entry['hook'] !== $hook) {
+                continue;
+            }
+            if ($group !== '' && $entry['group'] !== $group) {
+                continue;
+            }
+            if ($args !== null && $entry['args'] !== $args) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+}
+
 if (!function_exists('wp_upload_dir')) {
     /**
      * Mock wp_upload_dir function


### PR DESCRIPTION
* Order_Handler::handle_bulk_action no longer generates invoices inline. Each eligible post_id is enqueued via as_enqueue_async_action('b2brouter_bulk_generate_invoice', ['order_id' => $id], 'b2brouter'). Already-invoiced orders are pre-filtered through has_invoice() and counted as skipped, so they don't surface as run-time failures in the AS UI. Missing orders are dropped silently — error counts can't be known at redirect time.
* New Order_Handler::process_queued_invoice($order_id) is the AS worker, registered against the b2brouter_bulk_generate_invoice hook. Delegates to Invoice_Generator::generate_invoice, whose existing order note keeps working as the per-order user-facing signal; AS logs the action result as a second surface.
* Order_Handler::bulk_action_notices replaces the success/error pair with a single notice-info "N invoices queued" message and a deep link to Scheduled Actions. AS's list table doesn't honor `group=`, so the link uses `s=b2brouter_bulk_generate_invoice` to narrow by hook name. Skipped-warning copy now covers both reasons (not completed, or already invoiced).
* tests/bootstrap.php adds an as_enqueue_async_action stub mirroring the wp_schedule_event pattern.
* tests/OrderHandlerTest.php rewrites bulk-action coverage to assert on enqueue side effects instead of generator calls; adds cases for the pre-filter, worker hook registration, worker delegation, and new notice copy.
* README documents that AS depends on a working WP-Cron.

Closes #37.