### PR TITLE
Remove staging environment selector, default to production (closes #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to B2Brouter for WooCommerce will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Environment Selector**: Removed the staging/production environment radio from the settings page. The plugin now always defaults to production; developers can point at staging or a local B2Brouter instance via the `B2BROUTER_API_BASE` (and parallel `B2BROUTER_WEB_BASE`) constants in `wp-config.php` — replaces the previous `B2BROUTER_DEV_API_BASE` constant (closes #10)
+- **Order Meta Box**: The "View in B2Brouter" link now respects `Settings::get_web_app_base_url()` instead of hardcoding the production app URL
+
 ## [0.9.4] - 2026-04-23
 
 Final pre-release before 1.0. Focused on stability, operational polish, and preparing the plugin for distribution via the WordPress.org plugin directory and the WooCommerce Marketplace.

--- a/README.md
+++ b/README.md
@@ -116,9 +116,7 @@ Get real-time invoice status updates in your WooCommerce orders with two sync me
 ### API Integration
 
 - **B2Brouter PHP SDK**: Built on official B2Brouter PHP SDK (v1.0.0+)
-- **Environment Support**:
-  - Staging: `https://api-staging.b2brouter.net`
-  - Production: `https://api.b2brouter.net`
+- **Production API**: `https://api.b2brouter.net` (overridable for development via the `B2BROUTER_API_BASE` constant in `wp-config.php`)
 - **API Key Validation**: Real-time validation with account information retrieval
 - **Structured Data Exchange**: Sends structured invoice data (not just PDFs)
 - **Electronic Invoice Formats**: Supports UBL, Facturae, and other formats via B2Brouter
@@ -180,8 +178,7 @@ See [DISTRIBUTION.md](docs/DISTRIBUTION.md) for release procedures.
 1. Navigate to **Invoices → Settings** in WordPress admin
 2. Enter your B2Brouter API key
 3. Click **Validate Key** to verify connectivity and retrieve account information
-4. Select environment (Staging or Production)
-5. Save settings
+4. Save settings
 
 ### Invoice Generation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -283,13 +283,10 @@ $accounts = $client->accounts->all(['limit' => 1]);
 
 ### API Endpoints
 
-**Staging Environment**:
-- Base URL: `https://api-staging.b2brouter.net`
-- Use for testing and development
+**Production**:
+- Base URL: `https://api.b2brouter.net` (default)
 
-**Production Environment**:
-- Base URL: `https://api.b2brouter.net`
-- Use for live transactions
+The base URL can be overridden in `wp-config.php` via the `B2BROUTER_API_BASE` constant — used to point local installs at staging (`https://api-staging.b2brouter.net`) or at a developer's local B2Brouter instance.
 
 **Webhook Endpoint**:
 - REST API: `/wp-json/b2brouter/v1/webhook`

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -304,11 +304,8 @@ Test with real WordPress/WooCommerce:
 1. **Set up local environment** (see [LOCAL_DEVELOPMENT_SETUP.md](LOCAL_DEVELOPMENT_SETUP.md))
 
 2. **Configure API key:**
-   ```bash
-   # Use staging environment
-   export B2BROUTER_API_KEY="your-test-key"
-   export B2BROUTER_ENVIRONMENT="staging"
-   ```
+   - Add a staging key in **Invoices → Settings**
+   - Point the plugin at staging by defining `B2BROUTER_API_BASE` (and optionally `B2BROUTER_WEB_BASE`) in `wp-config.php` — see [LOCAL_DEVELOPMENT_SETUP.md](LOCAL_DEVELOPMENT_SETUP.md)
 
 3. **Create test order:**
    - WooCommerce → Orders → Add New
@@ -321,7 +318,7 @@ Test with real WordPress/WooCommerce:
    - Automatic: Set mode to automatic and complete order
 
 5. **Verify in B2Brouter:**
-   - Go to https://app-staging.b2brouter.net
+   - Open the staging web app (`https://app-staging.b2brouter.net`)
    - Check invoice was created
 
 ### Manual Testing Checklist
@@ -332,7 +329,6 @@ Before releasing:
 - [ ] Plugin activates without errors
 - [ ] Settings page loads correctly
 - [ ] API key validation works (both valid/invalid)
-- [ ] Environment switching works (staging/production)
 - [ ] Manual invoice generation works
 - [ ] Automatic invoice generation works
 - [ ] Bulk invoice generation works

--- a/docs/LOCAL_DEVELOPMENT_SETUP.md
+++ b/docs/LOCAL_DEVELOPMENT_SETUP.md
@@ -98,7 +98,7 @@ If you're running a local instance of B2Brouter (not needed for most developers)
 
 ```php
 /* Set B2Brouter API URL for local development */
-define( 'B2BROUTER_DEV_API_BASE', 'http://api.b2brouter.local:3001' );
+define( 'B2BROUTER_API_BASE', 'http://api.b2brouter.local:3001' );
 ```
 
 See [Connecting to Local B2Brouter Instance](#connecting-to-local-b2brouter-instance) for complete setup instructions.
@@ -222,13 +222,13 @@ Add this line **before** the `/* That's all, stop editing! */` comment:
 
 ```php
 /* Set B2Brouter API URL for local development */
-define( 'B2BROUTER_DEV_API_BASE', 'http://api.b2brouter.local:3001' );
+define( 'B2BROUTER_API_BASE', 'http://api.b2brouter.local:3001' );
 ```
 
 **How it works:**
-- The plugin checks for the `B2BROUTER_DEV_API_BASE` constant in `Settings::get_api_base_url()` (Settings.php:127-129)
-- If defined, it overrides the environment-based API URL (production/staging)
-- This allows testing against your local B2Brouter instance without changing plugin code
+- `Settings::get_api_base_url()` defaults to production (`https://api.b2brouter.net`) and uses the `B2BROUTER_API_BASE` constant when it is defined
+- This allows testing against your local B2Brouter instance — or against staging — without changing plugin code
+- A parallel `B2BROUTER_WEB_BASE` constant overrides the web app URL used by admin links (e.g. the "View in B2Brouter" button on the order screen)
 
 ### Step 3: Set Up Local B2Brouter Account
 
@@ -332,24 +332,25 @@ define( 'B2BROUTER_DEV_API_BASE', 'http://api.b2brouter.local:3001' );
    - Check the order notes for "Status updated via webhook" message
    - Verify the status badge updates in the order meta box
 
-### Step 7: Switching Between Local and Staging
+### Step 7: Switching Between Local, Staging, and Production
 
-**To test against local B2Brouter:**
-- Keep `B2BROUTER_DEV_API_BASE` defined in `wp-config.php`
-- Use local API key and webhook secret
+The plugin always defaults to production (`https://api.b2brouter.net`). Override the target environment via the `B2BROUTER_API_BASE` constant in `wp-config.php`:
 
-**To test against staging B2Brouter:**
+**Local B2Brouter:**
 ```php
-// In wp-config.php, comment out or remove:
-// define( 'B2BROUTER_DEV_API_BASE', 'http://api.b2brouter.local:3001' );
+define( 'B2BROUTER_API_BASE', 'http://api.b2brouter.local:3001' );
+define( 'B2BROUTER_WEB_BASE', 'http://app.b2brouter.local' );
 ```
-- Go to **Invoices → Settings**
-- Select **Environment: Staging**
-- Enter staging API key
-- Configure staging webhook secret
-- Save settings
 
-The plugin will automatically use `https://api-staging.b2brouter.net` when the constant is not defined.
+**Staging:**
+```php
+define( 'B2BROUTER_API_BASE', 'https://api-staging.b2brouter.net' );
+define( 'B2BROUTER_WEB_BASE', 'https://app-staging.b2brouter.net' );
+```
+
+**Production:** remove (or comment out) both `B2BROUTER_API_BASE` and `B2BROUTER_WEB_BASE` — the plugin falls back to the production URLs.
+
+In each case, replace the API key and webhook secret in **Invoices → Settings** with credentials for the target environment.
 
 ### Debugging Local Development
 
@@ -406,7 +407,7 @@ curl -X POST "http://localhost:8000/index.php?rest_route=/b2brouter/v1/webhook" 
    - REST API is not enabled - check WordPress Settings → Permalinks
 
 2. **"API key not configured" or "Invalid API key"**
-   - Verify `B2BROUTER_DEV_API_BASE` is correctly defined
+   - Verify `B2BROUTER_API_BASE` is correctly defined
    - Check local B2Brouter API is running
    - Ensure API key is valid in local instance
 
@@ -422,11 +423,13 @@ curl -X POST "http://localhost:8000/index.php?rest_route=/b2brouter/v1/webhook" 
 
 ### Architecture Notes for Developers
 
-**API Base URL Priority (Settings.php:124-132):**
-1. `B2BROUTER_DEV_API_BASE` constant (if defined) - Highest priority
-2. Environment setting from admin:
-   - Production: `https://api.b2brouter.net`
-   - Staging: `https://staging.api.b2brouter.net`
+**API Base URL Resolution (`Settings::get_api_base_url()`):**
+1. `B2BROUTER_API_BASE` constant (if defined) - takes precedence
+2. Falls back to production: `https://api.b2brouter.net`
+
+**Web App URL Resolution (`Settings::get_web_app_base_url()`):**
+1. `B2BROUTER_WEB_BASE` constant (if defined) - takes precedence
+2. Falls back to production: `https://app.b2brouter.net`
 
 **Webhook Flow:**
 ```

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -150,7 +150,6 @@ class Admin {
      */
     public function register_settings() {
         register_setting('b2brouter_settings', 'b2brouter_api_key');
-        register_setting('b2brouter_settings', 'b2brouter_environment');
         register_setting('b2brouter_settings', 'b2brouter_invoice_mode');
     }
 
@@ -512,7 +511,6 @@ class Admin {
      */
     public function render_settings_page() {
         $api_key = $this->settings->get_api_key();
-        $environment = $this->settings->get_environment();
         $invoice_mode = $this->settings->get_invoice_mode();
         $auto_save_pdf = $this->settings->get_auto_save_pdf();
         $attach_to_completed = $this->settings->get_attach_to_order_completed();
@@ -533,12 +531,6 @@ class Admin {
                 $new_api_key = sanitize_text_field($_POST['b2brouter_api_key']);
                 $this->settings->set_api_key($new_api_key);
                 $api_key = $new_api_key;
-            }
-
-            // Save environment
-            if (isset($_POST['b2brouter_environment'])) {
-                $this->settings->set_environment(sanitize_text_field($_POST['b2brouter_environment']));
-                $environment = $this->settings->get_environment();
             }
 
             // Save invoice mode
@@ -741,35 +733,6 @@ class Admin {
                                 <?php esc_html_e('Enter your B2Brouter API key to enable invoice generation.', 'b2brouter-woocommerce'); ?>
                                 <a href="https://app.b2brouter.net" target="_blank"><?php esc_html_e('Get your API key', 'b2brouter-woocommerce'); ?></a>
                             </p>
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <th scope="row">
-                            <?php esc_html_e('Environment', 'b2brouter-woocommerce'); ?>
-                        </th>
-                        <td>
-                            <fieldset>
-                                <label>
-                                    <input type="radio"
-                                           name="b2brouter_environment"
-                                           value="staging"
-                                           <?php checked($environment, 'staging'); ?>>
-                                    <?php esc_html_e('Staging', 'b2brouter-woocommerce'); ?>
-                                    <code>api-staging.b2brouter.net</code>
-                                </label>
-                                <p class="description"><?php esc_html_e('Use staging environment for testing', 'b2brouter-woocommerce'); ?></p>
-
-                                <label>
-                                    <input type="radio"
-                                           name="b2brouter_environment"
-                                           value="production"
-                                           <?php checked($environment, 'production'); ?>>
-                                    <?php esc_html_e('Production', 'b2brouter-woocommerce'); ?>
-                                    <code>api.b2brouter.net</code>
-                                </label>
-                                <p class="description"><?php esc_html_e('Use production environment for live invoices', 'b2brouter-woocommerce'); ?></p>
-                            </fieldset>
                         </td>
                     </tr>
 

--- a/includes/Order_Handler.php
+++ b/includes/Order_Handler.php
@@ -447,11 +447,11 @@ class Order_Handler {
             <p>
                 <?php
                 // Build B2Brouter dashboard URL
-                $dashboard_url = 'https://app.b2brouter.net';
+                $dashboard_url = $this->settings->get_web_app_base_url();
                 if ($has_invoice) {
                     $invoice_id = $order->get_meta('_b2brouter_invoice_id');
                     if (!empty($invoice_id)) {
-                        $dashboard_url = 'https://app.b2brouter.net/invoices/' . urlencode($invoice_id);
+                        $dashboard_url .= '/invoices/' . urlencode($invoice_id);
                     }
                 }
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -24,7 +24,6 @@ class Settings {
     const OPTION_API_KEY = 'b2brouter_api_key';
     const OPTION_ACCOUNT_ID = 'b2brouter_account_id';
     const OPTION_ACCOUNT_NAME = 'b2brouter_account_name';
-    const OPTION_ENVIRONMENT = 'b2brouter_environment';
     const OPTION_INVOICE_MODE = 'b2brouter_invoice_mode';
     const OPTION_TRANSACTION_COUNT = 'b2brouter_transaction_count';
     const OPTION_SHOW_WELCOME = 'b2brouter_show_welcome';
@@ -117,64 +116,38 @@ class Settings {
     }
 
     /**
-     * Get environment (staging or production)
+     * Get API base URL.
      *
-     * @since 1.0.0
-     * @return string The environment ('staging' or 'production')
-     */
-    public function get_environment() {
-        return get_option(self::OPTION_ENVIRONMENT, 'staging');
-    }
-
-    /**
-     * Set environment
-     *
-     * @since 1.0.0
-     * @param string $environment The environment ('staging' or 'production')
-     * @return bool True on success, false on failure
-     */
-    public function set_environment($environment) {
-        if (in_array($environment, array('staging', 'production'))) {
-            return update_option(self::OPTION_ENVIRONMENT, $environment);
-        }
-        return false;
-    }
-
-    /**
-     * Get API base URL for current environment
+     * Defaults to production. Developers can override via the
+     * B2BROUTER_API_BASE constant in wp-config.php (e.g. to point at staging
+     * or a local B2Brouter instance).
      *
      * @since 1.0.0
      * @return string The API base URL
      */
     public function get_api_base_url() {
-        // Allow developers to override via wp-config.php constant
-        if (defined('B2BROUTER_DEV_API_BASE') && B2BROUTER_DEV_API_BASE) {
-            return B2BROUTER_DEV_API_BASE;
+        if (defined('B2BROUTER_API_BASE') && B2BROUTER_API_BASE) {
+            return B2BROUTER_API_BASE;
         }
 
-        $environment = $this->get_environment();
-
-        if ($environment === 'production') {
-            return 'https://api.b2brouter.net';
-        }
-
-        return 'https://api-staging.b2brouter.net';
+        return 'https://api.b2brouter.net';
     }
 
     /**
-     * Get web app base URL for current environment
+     * Get web app base URL.
+     *
+     * Defaults to production. Developers can override via the
+     * B2BROUTER_WEB_BASE constant in wp-config.php.
      *
      * @since 1.0.0
      * @return string The web app base URL
      */
     public function get_web_app_base_url() {
-        $environment = $this->get_environment();
-
-        if ($environment === 'production') {
-            return 'https://app.b2brouter.net';
+        if (defined('B2BROUTER_WEB_BASE') && B2BROUTER_WEB_BASE) {
+            return B2BROUTER_WEB_BASE;
         }
 
-        return 'https://app-staging.b2brouter.net';
+        return 'https://app.b2brouter.net';
     }
 
     /**

--- a/tests/InvoiceGeneratorTest.php
+++ b/tests/InvoiceGeneratorTest.php
@@ -186,7 +186,7 @@ class InvoiceGeneratorTest extends TestCase {
         $this->mock_settings->method('get_auto_save_pdf')
                            ->willReturn(false); // Don't auto-save PDF in this test
         $this->mock_settings->method('get_api_base_url')
-                           ->willReturn('https://api-staging.b2brouter.net');
+                           ->willReturn('https://api.b2brouter.net');
         $this->mock_settings->expects($this->once())
                            ->method('increment_transaction_count');
 

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -72,7 +72,6 @@ class SettingsTest extends TestCase {
     public function test_constants_are_defined() {
         $this->assertEquals('b2brouter_api_key', Settings::OPTION_API_KEY);
         $this->assertEquals('b2brouter_account_id', Settings::OPTION_ACCOUNT_ID);
-        $this->assertEquals('b2brouter_environment', Settings::OPTION_ENVIRONMENT);
         $this->assertEquals('b2brouter_invoice_mode', Settings::OPTION_INVOICE_MODE);
         $this->assertEquals('b2brouter_transaction_count', Settings::OPTION_TRANSACTION_COUNT);
         $this->assertEquals('b2brouter_show_welcome', Settings::OPTION_SHOW_WELCOME);
@@ -213,87 +212,26 @@ class SettingsTest extends TestCase {
         $this->assertEquals('Company Name', $this->settings->get_account_name());
     }
 
-    // ========== Environment Tests ==========
+    // ========== API Base URL Tests ==========
 
     /**
-     * Test get_environment returns 'staging' by default
+     * Test get_api_base_url returns the production URL by default
      *
      * @return void
      */
-    public function test_get_environment_returns_staging_by_default() {
-        $environment = $this->settings->get_environment();
-        $this->assertEquals('staging', $environment);
-    }
-
-    /**
-     * Test set_environment accepts 'staging'
-     *
-     * @return void
-     */
-    public function test_set_environment_accepts_staging() {
-        $result = $this->settings->set_environment('staging');
-        $this->assertTrue($result);
-        $this->assertEquals('staging', $this->settings->get_environment());
-    }
-
-    /**
-     * Test set_environment accepts 'production'
-     *
-     * @return void
-     */
-    public function test_set_environment_accepts_production() {
-        $result = $this->settings->set_environment('production');
-        $this->assertTrue($result);
-        $this->assertEquals('production', $this->settings->get_environment());
-    }
-
-    /**
-     * Test set_environment rejects invalid values
-     *
-     * @return void
-     */
-    public function test_set_environment_rejects_invalid_values() {
-        $result = $this->settings->set_environment('invalid');
-        $this->assertFalse($result);
-
-        $result = $this->settings->set_environment('');
-        $this->assertFalse($result);
-
-        $result = $this->settings->set_environment('PRODUCTION');
-        $this->assertFalse($result);
-    }
-
-    /**
-     * Test get_api_base_url returns staging URL by default
-     *
-     * @return void
-     */
-    public function test_get_api_base_url_returns_staging_by_default() {
-        $url = $this->settings->get_api_base_url();
-        $this->assertEquals('https://api-staging.b2brouter.net', $url);
-    }
-
-    /**
-     * Test get_api_base_url returns production URL when set
-     *
-     * @return void
-     */
-    public function test_get_api_base_url_returns_production_when_set() {
-        $this->settings->set_environment('production');
+    public function test_get_api_base_url_returns_production_by_default() {
         $url = $this->settings->get_api_base_url();
         $this->assertEquals('https://api.b2brouter.net', $url);
     }
 
     /**
-     * Test get_api_base_url returns staging URL when explicitly set
+     * Test get_web_app_base_url returns the production URL by default
      *
      * @return void
      */
-    public function test_get_api_base_url_returns_staging_when_set() {
-        $this->settings->set_environment('production');
-        $this->settings->set_environment('staging');
-        $url = $this->settings->get_api_base_url();
-        $this->assertEquals('https://api-staging.b2brouter.net', $url);
+    public function test_get_web_app_base_url_returns_production_by_default() {
+        $url = $this->settings->get_web_app_base_url();
+        $this->assertEquals('https://app.b2brouter.net', $url);
     }
 
     // ========== Invoice Mode Tests ==========
@@ -1020,9 +958,8 @@ class SettingsTest extends TestCase {
             'set_account_id',
             'get_account_name',
             'set_account_name',
-            'get_environment',
-            'set_environment',
             'get_api_base_url',
+            'get_web_app_base_url',
             'get_invoice_mode',
             'set_invoice_mode',
             'get_transaction_count',

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -234,6 +234,36 @@ class SettingsTest extends TestCase {
         $this->assertEquals('https://app.b2brouter.net', $url);
     }
 
+    /**
+     * Test get_api_base_url returns the value of B2BROUTER_API_BASE when defined.
+     *
+     * Run in a separate process because define() is process-global and one-shot.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     * @return void
+     */
+    public function test_get_api_base_url_uses_constant_when_defined() {
+        define('B2BROUTER_API_BASE', 'https://api-staging.b2brouter.net');
+        $settings = new Settings();
+        $this->assertEquals('https://api-staging.b2brouter.net', $settings->get_api_base_url());
+    }
+
+    /**
+     * Test get_web_app_base_url returns the value of B2BROUTER_WEB_BASE when defined.
+     *
+     * Run in a separate process because define() is process-global and one-shot.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     * @return void
+     */
+    public function test_get_web_app_base_url_uses_constant_when_defined() {
+        define('B2BROUTER_WEB_BASE', 'https://app-staging.b2brouter.net');
+        $settings = new Settings();
+        $this->assertEquals('https://app-staging.b2brouter.net', $settings->get_web_app_base_url());
+    }
+
     // ========== Invoice Mode Tests ==========
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1121,7 +1121,7 @@ if (!class_exists('B2BRouter\B2BRouterClient')) {
         class B2BRouterClient {
             public $invoices;
             private $apiKey;
-            private $apiBase = "https://api-staging.b2brouter.net";
+            private $apiBase = "https://api.b2brouter.net";
             private $apiVersion = "2025-10-13";
             private $httpClient;
             private $timeout = 80;


### PR DESCRIPTION
The settings page no longer exposes a staging/production radio. The plugin always defaults to production. Developers point at staging or a local B2Brouter instance via the new
B2BROUTER_API_BASE (and parallel B2BROUTER_WEB_BASE) constants in wp-config.php, which replace the previous B2BROUTER_DEV_API_BASE.

Also fixes the "View in B2Brouter" link in the order meta box, which previously hardcoded the production web app URL instead of using Settings::get_web_app_base_url().