### PR TITLE
Document explicit compliance scope for Verifactu, TicketBAI, DGFiP, KSeF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Final pre-release before 1.0. Focused on stability, operational polish, and preparing the plugin for distribution via the WordPress.org plugin directory and the WooCommerce Marketplace.
 
+### Compliance scope
+
+Documented explicit support for four national / regional e-invoicing regimes:
+
+- **Spain — Verifactu**: automatic AEAT reporting with QR verification (state-wide).
+- **Spain (Basque Country) — TicketBAI**: automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba.
+- **France — DGFiP**: routing via PPF / Chorus Pro.
+- **Poland — KSeF**: automatic submission to the national system.
+
+General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers (Verifactu / TicketBAI certificates, KSeF tokens, Chorus Pro IDs, etc.) are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
+
 ### Added
 
 - **Internationalization**: Initial translation files for Catalan (ca), German (de_DE), Spanish (es_ES), French (fr_FR), English (en_US), plus `.pot` template
@@ -231,7 +242,7 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 
 #### Tax Compliance
 - Automatic tax category detection for order line items
-- PEPPOL tax category support (S, E, Z, NS, AE)
+- Peppol tax category support (S, E, Z, NS, AE)
 - Intra-EU reverse charge detection for B2B transactions
 - Dynamic tax name localization (IVA, TVA, VAT, MwSt, GST)
 - Automatic merchant country detection from WooCommerce settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,13 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 
 ### Compliance scope
 
-Documented explicit support for four national / regional e-invoicing regimes:
+Documented explicit support for three national e-invoicing regimes:
 
-- **Spain — Verifactu**: automatic AEAT reporting with QR verification (state-wide).
-- **Spain (Basque Country) — TicketBAI**: automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba.
+- **Spain — Verifactu**: automatic AEAT reporting with QR verification.
 - **France — DGFiP**: routing via PPF / Chorus Pro.
 - **Poland — KSeF**: automatic submission to the national system.
 
-General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers (Verifactu / TicketBAI certificates, KSeF tokens, Chorus Pro IDs, etc.) are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
+General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers (Verifactu certificates, KSeF tokens, Chorus Pro IDs, etc.) are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 # B2Brouter for WooCommerce
 
-**Automated invoice generation and tax compliance for WooCommerce using B2Brouter's eDocExchange service.**
+**Automated e-invoicing for WooCommerce with built-in compliance for Spain (Verifactu and TicketBAI), France (DGFiP / PPF–Chorus Pro) and Poland (KSeF).**
 
-B2Brouter for WooCommerce integrates your WooCommerce store with B2Brouter's electronic invoicing platform, providing structured data exchange, multi-country tax compliance, and API-driven invoice delivery for B2B and B2C eCommerce.
+B2Brouter for WooCommerce connects your store to B2Brouter's eDocExchange platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
 [![Version](https://img.shields.io/badge/version-0.9.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![WordPress](https://img.shields.io/badge/WordPress-5.8%2B-blue.svg)](https://wordpress.org)
 [![WooCommerce](https://img.shields.io/badge/WooCommerce-5.0%2B-purple.svg)](https://woocommerce.com)
+
+---
+
+## Compliance scope
+
+The plugin includes explicit support for the following e-invoicing regimes:
+
+- **Spain — Verifactu**: Automatic AEAT reporting with QR verification on every issued invoice (state-wide regime).
+- **Spain (Basque Country) — TicketBAI**: Automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba, with the corresponding TBAI identifier and QR.
+- **France — DGFiP**: Routing through the official PPF / Chorus Pro infrastructure.
+- **Poland — KSeF**: Automatic submission of invoices to the national KSeF system.
+
+Beyond these explicit regimes, the plugin generates compliant electronic invoices (UBL, Facturae, Peppol) for the rest of the EU, the UK, and other jurisdictions supported by B2Brouter.
+
+> **Authority-specific configuration** (Verifactu / TicketBAI credentials, KSeF tokens, Chorus Pro identifiers, etc.) is managed in your **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
+
+> Need compliance for another country? [Open an issue](https://github.com/B2Brouter/b2brouter-woocommerce/issues/new) — we prioritise based on demand.
 
 ---
 
@@ -35,11 +52,11 @@ B2Brouter for WooCommerce integrates your WooCommerce store with B2Brouter's ele
 ### Tax Compliance
 
 - **Automatic Tax Category Detection**: Analyzes WooCommerce order data to determine appropriate tax categories for each line item
-- **PEPPOL Tax Categories**: Supports standard PEPPOL categories:
+- **Peppol Tax Categories**: Supports standard Peppol categories:
   - **S** (Standard rate): Applied when taxes exist
   - **E** (Exempt from tax): Taxable items with 0% rate
   - **Z** (Zero-rated goods): Items with explicit zero-rate tax class
-  - **NS** (Not subject to tax): Non-taxable items (B2Brouter maps to PEPPOL G or O based on context)
+  - **NS** (Not subject to tax): Non-taxable items (B2Brouter maps to Peppol G or O based on context)
   - **AE** (VAT Reverse Charge): Automatically detected for intra-EU B2B transactions
 - **Intra-EU Reverse Charge**: Automatic detection based on customer TIN and country comparison
 - **Dynamic Tax Names**: Tax names automatically localized by supplier country (IVA, TVA, VAT, MwSt, GST, etc.)
@@ -122,7 +139,7 @@ Get real-time invoice status updates in your WooCommerce orders with two sync me
 - **API Key Validation**: Real-time validation with account information retrieval
 - **Structured Data Exchange**: Sends structured invoice data (not just PDFs)
 - **Electronic Invoice Formats**: Supports UBL, Facturae, and other formats via B2Brouter
-- **Multi-Country Compliance**: B2Brouter adapts invoice requirements for PEPPOL and non-PEPPOL countries
+- **Multi-Country Compliance**: B2Brouter adapts invoice requirements for Peppol and non-Peppol countries — see [Compliance scope](#compliance-scope) for the regimes explicitly supported
 
 ---
 
@@ -276,7 +293,7 @@ The plugin reads tax configuration from WooCommerce:
 - Create tax class named "Zero Rate"
 - Set tax rate to 0%
 - Assign to products
-- Plugin uses PEPPOL category Z
+- Plugin uses Peppol category Z
 
 **Non-Taxable Products**:
 - Set product **Tax Status** to "None"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # B2Brouter for WooCommerce
 
-**Automated e-invoicing for WooCommerce with built-in compliance for Spain (Verifactu and TicketBAI), France (DGFiP / PPF–Chorus Pro) and Poland (KSeF).**
+**Automated e-invoicing for WooCommerce with built-in compliance for Spain (Verifactu), France (DGFiP / PPF–Chorus Pro) and Poland (KSeF).**
 
-B2Brouter for WooCommerce connects your store to B2Brouter's eDocExchange platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
+B2Brouter for WooCommerce connects your store to B2Brouter's platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
 [![Version](https://img.shields.io/badge/version-0.9.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -15,14 +15,13 @@ B2Brouter for WooCommerce connects your store to B2Brouter's eDocExchange platfo
 
 The plugin includes explicit support for the following e-invoicing regimes:
 
-- **Spain — Verifactu**: Automatic AEAT reporting with QR verification on every issued invoice (state-wide regime).
-- **Spain (Basque Country) — TicketBAI**: Automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba, with the corresponding TBAI identifier and QR.
+- **Spain — Verifactu**: Automatic AEAT reporting with QR verification on every issued invoice.
 - **France — DGFiP**: Routing through the official PPF / Chorus Pro infrastructure.
 - **Poland — KSeF**: Automatic submission of invoices to the national KSeF system.
 
 Beyond these explicit regimes, the plugin generates compliant electronic invoices (UBL, Facturae, Peppol) for the rest of the EU, the UK, and other jurisdictions supported by B2Brouter.
 
-> **Authority-specific configuration** (Verifactu / TicketBAI credentials, KSeF tokens, Chorus Pro identifiers, etc.) is managed in your **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
+> **Authority-specific configuration** (Verifactu credentials, KSeF tokens, Chorus Pro identifiers, etc.) is managed in your **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
 
 > Need compliance for another country? [Open an issue](https://github.com/B2Brouter/b2brouter-woocommerce/issues/new) — we prioritise based on demand.
 

--- a/b2brouter-woocommerce.php
+++ b/b2brouter-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: B2Brouter for WooCommerce
  * Plugin URI: https://b2brouter.net
- * Description: Electronic invoicing for WooCommerce with compliance for Spain (Verifactu, TicketBAI), France (DGFiP) and Poland (KSeF), plus general e-invoicing for the EU and beyond.
+ * Description: Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu), France (DGFiP), Poland (KSeF) and general EU e-invoicing.
  * Version: 0.9.4
  * Author: B2Brouter
  * Author URI: https://b2brouter.net

--- a/b2brouter-woocommerce.php
+++ b/b2brouter-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: B2Brouter for WooCommerce
  * Plugin URI: https://b2brouter.net
- * Description: Generate and send electronic invoices from WooCommerce orders using B2Brouter
+ * Description: Electronic invoicing for WooCommerce with compliance for Spain (Verifactu, TicketBAI), France (DGFiP) and Poland (KSeF), plus general e-invoicing for the EU and beyond.
  * Version: 0.9.4
  * Author: B2Brouter
  * Author URI: https://b2brouter.net

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -336,14 +336,14 @@ WooCommerce order data is transformed to B2Brouter format:
 **Tax Handling**:
 - Merchant country extracted from WooCommerce settings
 - Tax name localized by country (IVA, TVA, VAT, etc.)
-- PEPPOL category determined per line item
+- Peppol category determined per line item
 - Intra-EU reverse charge automatically detected
 
 ### Country-specific compliance regimes
 
-The plugin does **not** implement the wire-format or transmission protocol of any specific tax authority. Country-specific compliance regimes explicitly supported in this release — Spain Verifactu, Spain TicketBAI (Bizkaia / Gipuzkoa / Araba), France DGFiP (PPF / Chorus Pro) and Poland KSeF — are handled entirely by B2Brouter's platform once a structured invoice is submitted via the SDK.
+The plugin does **not** implement the wire-format or transmission protocol of any specific tax authority. Country-specific compliance regimes explicitly supported in this release — Spain Verifactu, France DGFiP (PPF / Chorus Pro) and Poland KSeF — are handled entirely by B2Brouter's platform once a structured invoice is submitted via the SDK.
 
-Authority-specific configuration (Verifactu and TicketBAI certificates, KSeF authorization tokens, Chorus Pro identifiers, etc.) lives in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only requires an API key; the dashboard determines which regimes apply to each organizational unit.
+Authority-specific configuration (Verifactu certificates, KSeF authorization tokens, Chorus Pro identifiers, etc.) lives in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only requires an API key; the dashboard determines which regimes apply to each organizational unit.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,6 +339,12 @@ WooCommerce order data is transformed to B2Brouter format:
 - PEPPOL category determined per line item
 - Intra-EU reverse charge automatically detected
 
+### Country-specific compliance regimes
+
+The plugin does **not** implement the wire-format or transmission protocol of any specific tax authority. Country-specific compliance regimes explicitly supported in this release — Spain Verifactu, Spain TicketBAI (Bizkaia / Gipuzkoa / Araba), France DGFiP (PPF / Chorus Pro) and Poland KSeF — are handled entirely by B2Brouter's platform once a structured invoice is submitted via the SDK.
+
+Authority-specific configuration (Verifactu and TicketBAI certificates, KSeF authorization tokens, Chorus Pro identifiers, etc.) lives in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only requires an API key; the dashboard determines which regimes apply to each organizational unit.
+
 ---
 
 ## Extension Points

--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -395,7 +395,7 @@ class Invoice_Generator {
                 'price' => $price,
             );
 
-            // Always add tax information (PEPPOL compliant)
+            // Always add tax information (Peppol compliant)
             $tax_rate = $this->get_item_tax_rate($item, $item_order);
             $tax_info = $this->get_peppol_tax_category($item, $item_order, $tax_rate);
             $line['taxes_attributes'] = array(
@@ -431,7 +431,7 @@ class Invoice_Generator {
                 'price' => $shipping_price,
             );
 
-            // Always add tax information for shipping (PEPPOL compliant)
+            // Always add tax information for shipping (Peppol compliant)
             $shipping_tax_rate = $this->get_shipping_tax_rate($item_order);
             $merchant_country = $this->get_merchant_country();
             $tax_name = $this->get_tax_name($merchant_country);
@@ -1474,7 +1474,7 @@ class Invoice_Generator {
     }
 
     /**
-     * Get PEPPOL tax category and details for an item
+     * Get Peppol tax category and details for an item
      *
      * @since 1.0.0
      * @param \WC_Order_Item_Product $item The order item

--- a/tests/InvoiceGeneratorTest.php
+++ b/tests/InvoiceGeneratorTest.php
@@ -1179,7 +1179,7 @@ class InvoiceGeneratorTest extends TestCase {
         $this->assertEquals('R01-222', Invoice_Generator::format_invoice_number('222', 'R01'));
     }
 
-    // ========== Tax Handling Tests (PEPPOL Compliance) ==========
+    // ========== Tax Handling Tests (Peppol Compliance) ==========
 
     /**
      * Test get_merchant_country extracts country from WooCommerce settings


### PR DESCRIPTION
Lead with supported regimes instead of generic "multi-country compliance" so merchants in Spain, France and Poland can immediately tell whether the plugin covers their regulatory needs. Clarify that authority-specific configuration lives in the B2Brouter dashboard, not the plugin UI.

- README.md: new "Compliance scope" section above Features.
- CHANGELOG.md: compliance scope subsection inside the 0.9.4 entry.
- b2brouter-woocommerce.php: plugin Description rewritten with the four regimes; version unchanged at 0.9.4.
- docs/ARCHITECTURE.md: note that wire-format and transmission are delegated to B2Brouter.

Closes #39.