### PR TITLE
Add wp.org-format readme.txt for plugin directory submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Final pre-release before 1.0. Focused on stability, operational polish, and preparing the plugin for distribution via the WordPress.org plugin directory and the WooCommerce Marketplace.
 
+### Compliance scope
+
+Documented explicit support for four national / regional e-invoicing regimes:
+
+- **Spain — Verifactu**: automatic AEAT reporting with QR verification (state-wide).
+- **Spain (Basque Country) — TicketBAI**: automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba.
+- **France — DGFiP**: routing via PPF / Chorus Pro.
+- **Poland — KSeF**: automatic submission to the national system.
+
+General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers (Verifactu / TicketBAI certificates, KSeF tokens, Chorus Pro IDs, etc.) are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
+
 ### Added
 
 - **Internationalization**: Initial translation files for Catalan (ca), German (de_DE), Spanish (es_ES), French (fr_FR), English (en_US), plus `.pot` template
@@ -231,7 +242,7 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 
 #### Tax Compliance
 - Automatic tax category detection for order line items
-- PEPPOL tax category support (S, E, Z, NS, AE)
+- Peppol tax category support (S, E, Z, NS, AE)
 - Intra-EU reverse charge detection for B2B transactions
 - Dynamic tax name localization (IVA, TVA, VAT, MwSt, GST)
 - Automatic merchant country detection from WooCommerce settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,13 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 
 ### Compliance scope
 
-Documented explicit support for four national / regional e-invoicing regimes:
+Documented explicit support for three national e-invoicing regimes:
 
-- **Spain — Verifactu**: automatic AEAT reporting with QR verification (state-wide).
-- **Spain (Basque Country) — TicketBAI**: automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba.
+- **Spain — Verifactu**: automatic AEAT reporting with QR verification.
 - **France — DGFiP**: routing via PPF / Chorus Pro.
 - **Poland — KSeF**: automatic submission to the national system.
 
-General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers (Verifactu / TicketBAI certificates, KSeF tokens, Chorus Pro IDs, etc.) are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
+General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers (Verifactu certificates, KSeF tokens, Chorus Pro IDs, etc.) are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 # B2Brouter for WooCommerce
 
-**Automated invoice generation and tax compliance for WooCommerce using B2Brouter's eDocExchange service.**
+**Automated e-invoicing for WooCommerce with built-in compliance for Spain (Verifactu and TicketBAI), France (DGFiP / PPF–Chorus Pro) and Poland (KSeF).**
 
-B2Brouter for WooCommerce integrates your WooCommerce store with B2Brouter's electronic invoicing platform, providing structured data exchange, multi-country tax compliance, and API-driven invoice delivery for B2B and B2C eCommerce.
+B2Brouter for WooCommerce connects your store to B2Brouter's eDocExchange platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
 [![Version](https://img.shields.io/badge/version-0.9.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![WordPress](https://img.shields.io/badge/WordPress-5.8%2B-blue.svg)](https://wordpress.org)
 [![WooCommerce](https://img.shields.io/badge/WooCommerce-5.0%2B-purple.svg)](https://woocommerce.com)
+
+---
+
+## Compliance scope
+
+The plugin includes explicit support for the following e-invoicing regimes:
+
+- **Spain — Verifactu**: Automatic AEAT reporting with QR verification on every issued invoice (state-wide regime).
+- **Spain (Basque Country) — TicketBAI**: Automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba, with the corresponding TBAI identifier and QR.
+- **France — DGFiP**: Routing through the official PPF / Chorus Pro infrastructure.
+- **Poland — KSeF**: Automatic submission of invoices to the national KSeF system.
+
+Beyond these explicit regimes, the plugin generates compliant electronic invoices (UBL, Facturae, Peppol) for the rest of the EU, the UK, and other jurisdictions supported by B2Brouter.
+
+> **Authority-specific configuration** (Verifactu / TicketBAI credentials, KSeF tokens, Chorus Pro identifiers, etc.) is managed in your **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
+
+> Need compliance for another country? [Open an issue](https://github.com/B2Brouter/b2brouter-woocommerce/issues/new) — we prioritise based on demand.
 
 ---
 
@@ -35,11 +52,11 @@ B2Brouter for WooCommerce integrates your WooCommerce store with B2Brouter's ele
 ### Tax Compliance
 
 - **Automatic Tax Category Detection**: Analyzes WooCommerce order data to determine appropriate tax categories for each line item
-- **PEPPOL Tax Categories**: Supports standard PEPPOL categories:
+- **Peppol Tax Categories**: Supports standard Peppol categories:
   - **S** (Standard rate): Applied when taxes exist
   - **E** (Exempt from tax): Taxable items with 0% rate
   - **Z** (Zero-rated goods): Items with explicit zero-rate tax class
-  - **NS** (Not subject to tax): Non-taxable items (B2Brouter maps to PEPPOL G or O based on context)
+  - **NS** (Not subject to tax): Non-taxable items (B2Brouter maps to Peppol G or O based on context)
   - **AE** (VAT Reverse Charge): Automatically detected for intra-EU B2B transactions
 - **Intra-EU Reverse Charge**: Automatic detection based on customer TIN and country comparison
 - **Dynamic Tax Names**: Tax names automatically localized by supplier country (IVA, TVA, VAT, MwSt, GST, etc.)
@@ -122,7 +139,7 @@ Get real-time invoice status updates in your WooCommerce orders with two sync me
 - **API Key Validation**: Real-time validation with account information retrieval
 - **Structured Data Exchange**: Sends structured invoice data (not just PDFs)
 - **Electronic Invoice Formats**: Supports UBL, Facturae, and other formats via B2Brouter
-- **Multi-Country Compliance**: B2Brouter adapts invoice requirements for PEPPOL and non-PEPPOL countries
+- **Multi-Country Compliance**: B2Brouter adapts invoice requirements for Peppol and non-Peppol countries — see [Compliance scope](#compliance-scope) for the regimes explicitly supported
 
 ---
 
@@ -276,7 +293,7 @@ The plugin reads tax configuration from WooCommerce:
 - Create tax class named "Zero Rate"
 - Set tax rate to 0%
 - Assign to products
-- Plugin uses PEPPOL category Z
+- Plugin uses Peppol category Z
 
 **Non-Taxable Products**:
 - Set product **Tax Status** to "None"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # B2Brouter for WooCommerce
 
-**Automated e-invoicing for WooCommerce with built-in compliance for Spain (Verifactu and TicketBAI), France (DGFiP / PPF–Chorus Pro) and Poland (KSeF).**
+**Automated e-invoicing for WooCommerce with built-in compliance for Spain (Verifactu), France (DGFiP / PPF–Chorus Pro) and Poland (KSeF).**
 
-B2Brouter for WooCommerce connects your store to B2Brouter's eDocExchange platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
+B2Brouter for WooCommerce connects your store to B2Brouter's platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
 [![Version](https://img.shields.io/badge/version-0.9.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -15,14 +15,13 @@ B2Brouter for WooCommerce connects your store to B2Brouter's eDocExchange platfo
 
 The plugin includes explicit support for the following e-invoicing regimes:
 
-- **Spain — Verifactu**: Automatic AEAT reporting with QR verification on every issued invoice (state-wide regime).
-- **Spain (Basque Country) — TicketBAI**: Automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba, with the corresponding TBAI identifier and QR.
+- **Spain — Verifactu**: Automatic AEAT reporting with QR verification on every issued invoice.
 - **France — DGFiP**: Routing through the official PPF / Chorus Pro infrastructure.
 - **Poland — KSeF**: Automatic submission of invoices to the national KSeF system.
 
 Beyond these explicit regimes, the plugin generates compliant electronic invoices (UBL, Facturae, Peppol) for the rest of the EU, the UK, and other jurisdictions supported by B2Brouter.
 
-> **Authority-specific configuration** (Verifactu / TicketBAI credentials, KSeF tokens, Chorus Pro identifiers, etc.) is managed in your **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
+> **Authority-specific configuration** (Verifactu credentials, KSeF tokens, Chorus Pro identifiers, etc.) is managed in your **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
 
 > Need compliance for another country? [Open an issue](https://github.com/B2Brouter/b2brouter-woocommerce/issues/new) — we prioritise based on demand.
 

--- a/b2brouter-woocommerce.php
+++ b/b2brouter-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: B2Brouter for WooCommerce
  * Plugin URI: https://b2brouter.net
- * Description: Electronic invoicing for WooCommerce with compliance for Spain (Verifactu, TicketBAI), France (DGFiP) and Poland (KSeF), plus general e-invoicing for the EU and beyond.
+ * Description: Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu), France (DGFiP), Poland (KSeF) and general EU e-invoicing.
  * Version: 0.9.4
  * Author: B2Brouter
  * Author URI: https://b2brouter.net

--- a/b2brouter-woocommerce.php
+++ b/b2brouter-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: B2Brouter for WooCommerce
  * Plugin URI: https://b2brouter.net
- * Description: Generate and send electronic invoices from WooCommerce orders using B2Brouter
+ * Description: Electronic invoicing for WooCommerce with compliance for Spain (Verifactu, TicketBAI), France (DGFiP) and Poland (KSeF), plus general e-invoicing for the EU and beyond.
  * Version: 0.9.4
  * Author: B2Brouter
  * Author URI: https://b2brouter.net

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -336,14 +336,14 @@ WooCommerce order data is transformed to B2Brouter format:
 **Tax Handling**:
 - Merchant country extracted from WooCommerce settings
 - Tax name localized by country (IVA, TVA, VAT, etc.)
-- PEPPOL category determined per line item
+- Peppol category determined per line item
 - Intra-EU reverse charge automatically detected
 
 ### Country-specific compliance regimes
 
-The plugin does **not** implement the wire-format or transmission protocol of any specific tax authority. Country-specific compliance regimes explicitly supported in this release — Spain Verifactu, Spain TicketBAI (Bizkaia / Gipuzkoa / Araba), France DGFiP (PPF / Chorus Pro) and Poland KSeF — are handled entirely by B2Brouter's platform once a structured invoice is submitted via the SDK.
+The plugin does **not** implement the wire-format or transmission protocol of any specific tax authority. Country-specific compliance regimes explicitly supported in this release — Spain Verifactu, France DGFiP (PPF / Chorus Pro) and Poland KSeF — are handled entirely by B2Brouter's platform once a structured invoice is submitted via the SDK.
 
-Authority-specific configuration (Verifactu and TicketBAI certificates, KSeF authorization tokens, Chorus Pro identifiers, etc.) lives in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only requires an API key; the dashboard determines which regimes apply to each organizational unit.
+Authority-specific configuration (Verifactu certificates, KSeF authorization tokens, Chorus Pro identifiers, etc.) lives in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only requires an API key; the dashboard determines which regimes apply to each organizational unit.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,6 +339,12 @@ WooCommerce order data is transformed to B2Brouter format:
 - PEPPOL category determined per line item
 - Intra-EU reverse charge automatically detected
 
+### Country-specific compliance regimes
+
+The plugin does **not** implement the wire-format or transmission protocol of any specific tax authority. Country-specific compliance regimes explicitly supported in this release — Spain Verifactu, Spain TicketBAI (Bizkaia / Gipuzkoa / Araba), France DGFiP (PPF / Chorus Pro) and Poland KSeF — are handled entirely by B2Brouter's platform once a structured invoice is submitted via the SDK.
+
+Authority-specific configuration (Verifactu and TicketBAI certificates, KSeF authorization tokens, Chorus Pro identifiers, etc.) lives in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only requires an API key; the dashboard determines which regimes apply to each organizational unit.
+
 ---
 
 ## Extension Points

--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -395,7 +395,7 @@ class Invoice_Generator {
                 'price' => $price,
             );
 
-            // Always add tax information (PEPPOL compliant)
+            // Always add tax information (Peppol compliant)
             $tax_rate = $this->get_item_tax_rate($item, $item_order);
             $tax_info = $this->get_peppol_tax_category($item, $item_order, $tax_rate);
             $line['taxes_attributes'] = array(
@@ -431,7 +431,7 @@ class Invoice_Generator {
                 'price' => $shipping_price,
             );
 
-            // Always add tax information for shipping (PEPPOL compliant)
+            // Always add tax information for shipping (Peppol compliant)
             $shipping_tax_rate = $this->get_shipping_tax_rate($item_order);
             $merchant_country = $this->get_merchant_country();
             $tax_name = $this->get_tax_name($merchant_country);
@@ -1474,7 +1474,7 @@ class Invoice_Generator {
     }
 
     /**
-     * Get PEPPOL tax category and details for an item
+     * Get Peppol tax category and details for an item
      *
      * @since 1.0.0
      * @param \WC_Order_Item_Product $item The order item

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === B2Brouter for WooCommerce ===
 Contributors: B2Brouter
-Tags: woocommerce, e-invoicing, peppol, verifactu, ticketbai
+Tags: woocommerce, e-invoicing, peppol, verifactu, ksef
 Requires at least: 5.8
 Tested up to: 6.7
 Requires PHP: 7.4
@@ -8,7 +8,7 @@ Stable tag: 0.9.4
 License: MIT
 License URI: https://opensource.org/license/mit
 
-Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu, TicketBAI), France (DGFiP) and Poland (KSeF). EU + UK invoicing.
+Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu), France (DGFiP) and Poland (KSeF). EU + UK invoicing.
 
 == Description ==
 
@@ -18,14 +18,13 @@ Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu, TicketBAI
 
 The plugin includes explicit support for the following e-invoicing regimes:
 
-* **Spain — Verifactu**: automatic AEAT reporting with QR verification on every issued invoice (state-wide regime).
-* **Spain (Basque Country) — TicketBAI**: automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba, with the corresponding TBAI identifier and QR.
+* **Spain — Verifactu**: automatic AEAT reporting with QR verification on every issued invoice.
 * **France — DGFiP**: routing through the official PPF / Chorus Pro infrastructure.
 * **Poland — KSeF**: automatic submission of invoices to the national KSeF system.
 
 Beyond these explicit regimes, the plugin generates compliant electronic invoices in standard formats (UBL, Facturae, Peppol) for the rest of the EU, the UK, and other jurisdictions supported by B2Brouter.
 
-**Important:** Authority-specific configuration (Verifactu / TicketBAI certificates, KSeF tokens, Chorus Pro identifiers, etc.) is managed in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
+**Important:** Authority-specific configuration (Verifactu certificates, KSeF tokens, Chorus Pro identifiers, etc.) is managed in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
 
 = Key features =
 
@@ -61,7 +60,7 @@ Beyond these explicit regimes, the plugin generates compliant electronic invoice
 
 Yes. The plugin requires an active B2Brouter eDocExchange subscription. Sign up at [app.b2brouter.net](https://app.b2brouter.net) and obtain an API key under **Developers → API Keys**.
 
-= Where do I configure Verifactu, TicketBAI, KSeF or Chorus Pro? =
+= Where do I configure Verifactu, KSeF or Chorus Pro? =
 
 Authority-specific configuration (certificates, tokens, identifiers) is managed in your B2Brouter dashboard, not in the WordPress plugin UI. Once your dashboard is configured, the plugin transparently sends invoices through the appropriate regime.
 
@@ -106,7 +105,7 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 
 **Compliance scope:**
 
-* Documented explicit support for four national / regional e-invoicing regimes: Spain Verifactu, Spain TicketBAI (Basque Country), France DGFiP (PPF / Chorus Pro) and Poland KSeF. General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
+* Documented explicit support for three national e-invoicing regimes: Spain Verifactu, France DGFiP (PPF / Chorus Pro) and Poland KSeF. General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
 
 **Added:**
 
@@ -163,4 +162,4 @@ For the complete history, see `CHANGELOG.md` in the repository.
 
 = 0.9.4 =
 
-Final pre-release before 1.0. Filesystem API migration (required for wp.org), translations, and explicit compliance scope docs (Verifactu, TicketBAI, DGFiP, KSeF). Sequential and custom numbering modes removed — switch to Automatic or WooCommerce order number before upgrading.
+Final pre-release before 1.0. Filesystem API migration (required for wp.org), translations, and explicit compliance scope docs (Verifactu, DGFiP, KSeF). Sequential and custom numbering modes removed — switch to Automatic or WooCommerce order number before upgrading.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: B2Brouter
 Tags: woocommerce, e-invoicing, peppol, verifactu, ksef
 Requires at least: 5.8
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 0.9.4
 License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,166 @@
+=== B2Brouter for WooCommerce ===
+Contributors: B2Brouter
+Tags: woocommerce, e-invoicing, peppol, verifactu, ticketbai
+Requires at least: 5.8
+Tested up to: 6.7
+Requires PHP: 7.4
+Stable tag: 0.9.4
+License: MIT
+License URI: https://opensource.org/license/mit
+
+Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu, TicketBAI), France (DGFiP) and Poland (KSeF). EU + UK invoicing.
+
+== Description ==
+
+**B2Brouter for WooCommerce** connects your WooCommerce store with the B2Brouter platform to generate and send electronic invoices automatically — including the country-specific tax authority reporting required in Spain, France and Poland.
+
+= Built-in regulatory compliance =
+
+The plugin includes explicit support for the following e-invoicing regimes:
+
+* **Spain — Verifactu**: automatic AEAT reporting with QR verification on every issued invoice (state-wide regime).
+* **Spain (Basque Country) — TicketBAI**: automatic submission to the regional tax authorities of Bizkaia, Gipuzkoa and Araba, with the corresponding TBAI identifier and QR.
+* **France — DGFiP**: routing through the official PPF / Chorus Pro infrastructure.
+* **Poland — KSeF**: automatic submission of invoices to the national KSeF system.
+
+Beyond these explicit regimes, the plugin generates compliant electronic invoices in standard formats (UBL, Facturae, Peppol) for the rest of the EU, the UK, and other jurisdictions supported by B2Brouter.
+
+**Important:** Authority-specific configuration (Verifactu / TicketBAI certificates, KSeF tokens, Chorus Pro identifiers, etc.) is managed in the **B2Brouter dashboard**, not in the WordPress plugin UI. The plugin only needs your B2Brouter API key.
+
+= Key features =
+
+* **Automatic or manual invoice generation** — issue invoices on order completion or on demand from the order screen.
+* **Bulk invoice generation** — process multiple completed orders at once via WooCommerce bulk actions.
+* **Standard and simplified invoices** — IssuedInvoice (B2B with TIN) or IssuedSimplifiedInvoice (B2C without TIN), selected automatically.
+* **Credit notes for refunds** — generated on demand when a WooCommerce refund is created against an invoiced order.
+* **PDF generation, caching and email attachment** — store PDFs locally and attach them to order/customer/refund emails.
+* **Real-time invoice status** via webhooks (HMAC-SHA256 signed) with optional 6-hour fallback polling.
+* **TIN / VAT field at checkout** — works on both classic and block-based checkout (WooCommerce 8.6+); intra-EU reverse charge auto-detected.
+* **HPOS compatibility** — native support for High-Performance Order Storage (Custom Order Tables).
+* **Peppol tax categories** — automatic mapping (S, E, Z, NS, AE) from WooCommerce tax configuration.
+
+= Requirements =
+
+* WordPress 5.8 or higher
+* WooCommerce 5.0 or higher
+* PHP 7.4 or higher
+* Active B2Brouter eDocExchange subscription
+
+== Installation ==
+
+1. Download the plugin ZIP from the [GitHub releases page](https://github.com/B2Brouter/b2brouter-woocommerce/releases) (or install from the WordPress.org plugin directory once available).
+2. In WordPress admin, go to **Plugins → Add New → Upload Plugin** and select the ZIP file.
+3. Click **Install Now**, then **Activate Plugin**.
+4. Navigate to **Invoices → Settings**, paste your B2Brouter API key and click **Validate Key**.
+5. Choose **Automatic** or **Manual** invoice generation mode and configure series codes for invoices and credit notes.
+6. (Recommended) Configure webhooks under **Invoices → Settings → Webhook Configuration** for real-time status updates.
+
+== Frequently Asked Questions ==
+
+= Do I need a B2Brouter account? =
+
+Yes. The plugin requires an active B2Brouter eDocExchange subscription. Sign up at [app.b2brouter.net](https://app.b2brouter.net) and obtain an API key under **Developers → API Keys**.
+
+= Where do I configure Verifactu, TicketBAI, KSeF or Chorus Pro? =
+
+Authority-specific configuration (certificates, tokens, identifiers) is managed in your B2Brouter dashboard, not in the WordPress plugin UI. Once your dashboard is configured, the plugin transparently sends invoices through the appropriate regime.
+
+= Does the plugin work for countries outside Spain, France and Poland? =
+
+Yes. Beyond the explicitly supported compliance regimes, the plugin generates standard electronic invoices (UBL, Facturae, Peppol) for the rest of the EU, the UK and other jurisdictions supported by B2Brouter. Need explicit compliance for another country? [Open an issue](https://github.com/B2Brouter/b2brouter-woocommerce/issues/new).
+
+= Is HPOS (High-Performance Order Storage) supported? =
+
+Yes. The plugin declares full compatibility with WooCommerce HPOS / Custom Order Tables.
+
+= How do I get real-time invoice status updates? =
+
+Enable webhooks under **Invoices → Settings → Webhook Configuration**. Copy the auto-generated webhook URL into your B2Brouter dashboard (**Developers → Webhooks**), then paste the generated webhook secret back into WordPress. Updates arrive in under one second; a 6-hour fallback poll keeps things reliable.
+
+= Is the TIN/VAT field shown at checkout? =
+
+Yes, automatically. It works with both classic shortcode-based checkout and the new block-based checkout (WooCommerce 8.6+). The value is stored in `_billing_tin` on the order and on the customer profile for reuse.
+
+= Are credit notes generated automatically? =
+
+Credit notes are generated on demand for WooCommerce refunds when the parent order has an invoice. They follow the country-specific format (e.g. Spanish rectifying invoices) and are accessible from the order admin and from the customer's My Account page.
+
+= Are tests included? =
+
+Yes. The plugin ships with a PHPUnit test suite. See `docs/DEVELOPER_GUIDE.md` in the repository for instructions.
+
+== Screenshots ==
+
+1. Settings page with API key validation and account information.
+2. Order edit screen showing the B2Brouter Invoice meta box with status and PDF download.
+3. WooCommerce orders list with the invoice status column.
+4. List of Invoices admin page with bulk PDF download.
+5. Webhook configuration section.
+6. Customer "My Account" view with Download Invoice / Generate Invoice buttons.
+
+== Changelog ==
+
+= 0.9.4 =
+
+Final pre-release before 1.0. Focused on stability, operational polish, and preparing the plugin for distribution via the WordPress.org plugin directory and the WooCommerce Marketplace.
+
+**Compliance scope:**
+
+* Documented explicit support for four national / regional e-invoicing regimes: Spain Verifactu, Spain TicketBAI (Basque Country), France DGFiP (PPF / Chorus Pro) and Poland KSeF. General electronic invoicing (UBL / Facturae / Peppol) continues to work for the rest of the EU, the UK, and other countries supported by B2Brouter. Authority-specific credentials and identifiers are managed in the B2Brouter dashboard, not in the WordPress plugin UI.
+
+**Added:**
+
+* Initial translation files for Catalan, German, Spanish, French and English plus a `.pot` template.
+* Bulk "Generate Invoice" action on the HPOS orders screen; non-completed orders are skipped with a scoped admin notice.
+* Organizational unit selector when the connected B2Brouter account has multiple organizational units.
+* `uninstall.php` cleans up `b2brouter_*` options, sync timestamps and cached PDFs when the plugin is deleted.
+
+**Changed:**
+
+* Invoice numbering: removed sequential and custom numbering modes. Remaining modes are WooCommerce order number and automatic B2Brouter numbering.
+* Status sync: finalized invoices are no longer re-polled; stale non-final invoices use exponential backoff.
+* Service loading: admin services instantiated only in admin context and customer services only on the frontend.
+* Logging: replaced `error_log()` with `wc_get_logger()`. Plugin messages now appear under WooCommerce → Status → Logs (source `b2brouter-woocommerce`).
+* Filesystem operations: PDF reads, writes, deletions and directory operations now use the WP Filesystem API.
+* Welcome page redesigned; admin menu cleaned up (Welcome is the default landing page).
+
+**Fixed:**
+
+* Customer invoice download reliability from My Account → Orders.
+* `_b2brouter_invoice_date` now parsed in the site timezone.
+* Eliminated the duplicate save-success notice on the settings page.
+
+= 0.9.3 =
+
+* Real-time webhook integration (HMAC-SHA256 signed `issued_invoice.state_change` events; 5-minute timestamp window).
+* Smart polling strategy with optional 6-hour fallback when webhooks are enabled.
+* Admin menu renamed to "Invoices" with a new custom SVG icon.
+* Fixed TIN field saving for HPOS-enabled stores (classic checkout and admin order editing).
+
+= 0.9.2 =
+
+* Upgraded to B2Brouter PHP SDK v1.0.0.
+* Fixed credit note number collision for refunds.
+* Fixed WordPress 6.7.0 translation loading timing.
+* Fixed refund invoice generation under HPOS.
+* Improved invoice status sync UX (real status on creation instead of generic "draft").
+
+= 0.9.1 =
+
+* New "List of Invoices" admin page with pagination, sorting and bulk PDF download.
+* Invoice status sync system with hourly cron and color-coded badges.
+* Customer invoice generation from My Account in manual mode.
+* Customer credit note downloads from My Account.
+* Exponential backoff retry for PDF downloads.
+
+= 0.9.0 =
+
+* First public beta. Automatic / manual / bulk invoice generation, credit notes for refunds, PDF caching and email attachment, TIN/VAT collection, HPOS compatibility.
+
+For the complete history, see `CHANGELOG.md` in the repository.
+
+== Upgrade Notice ==
+
+= 0.9.4 =
+
+Final pre-release before 1.0. Filesystem API migration (required for wp.org), translations, and explicit compliance scope docs (Verifactu, TicketBAI, DGFiP, KSeF). Sequential and custom numbering modes removed — switch to Automatic or WooCommerce order number before upgrading.

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === B2Brouter for WooCommerce ===
-Contributors: B2Brouter
+Contributors: b2brouter
 Tags: woocommerce, e-invoicing, peppol, verifactu, ksef
 Requires at least: 5.8
 Tested up to: 6.9

--- a/tests/InvoiceGeneratorTest.php
+++ b/tests/InvoiceGeneratorTest.php
@@ -1179,7 +1179,7 @@ class InvoiceGeneratorTest extends TestCase {
         $this->assertEquals('R01-222', Invoice_Generator::format_invoice_number('222', 'R01'));
     }
 
-    // ========== Tax Handling Tests (PEPPOL Compliance) ==========
+    // ========== Tax Handling Tests (Peppol Compliance) ==========
 
     /**
      * Test get_merchant_country extracts country from WooCommerce settings


### PR DESCRIPTION
Required for distribution via the WordPress.org plugin directory: GitHub README.md and CHANGELOG.md are not parsed by wp.org; the directory needs its own readme.txt with a specific header (Contributors, Tags, Stable tag, Tested up to, etc.) and `== Section ==` body.

Mirrors the compliance-scope framing introduced in the previous PR (Verifactu, TicketBAI, DGFiP, KSeF) so the wp.org listing communicates the same scope as the GitHub README. Validated against the wp.org readme spec: 5 lowercase tags, short description ≤150 chars, Upgrade Notice ≤300 chars per version, MIT (GPLv2-compatible) licence.

Screenshots are listed by caption only; the actual PNG assets and the .wordpress-org/ directory will land in a separate PR.

Closes #31.