### PR TITLE
Bump WC tested up to from 8.5 to 10.7.

### DIFF
--- a/b2brouter-woocommerce.php
+++ b/b2brouter-woocommerce.php
@@ -13,7 +13,7 @@
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * WC requires at least: 5.0
- * WC tested up to: 8.5
+ * WC tested up to: 10.7
  *
  * @package B2Brouter\WooCommerce
  */

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require-dev": {
-        "php-stubs/woocommerce-stubs": "^10.3",
+        "php-stubs/woocommerce-stubs": "^10.7",
         "php-stubs/wordpress-stubs": "^6.8",
         "phpunit/phpunit": "^9.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "744938e1178170d68f96edb7bb47f395",
+    "content-hash": "62164999f68c81e0aa96b37f7250bbcb",
     "packages": [
         {
             "name": "b2brouter/b2brouter-php",
@@ -374,16 +374,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v10.3.5",
+            "version": "v10.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "4758987631eaa4cce89781bffb4ae7602d00a4cd"
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/4758987631eaa4cce89781bffb4ae7602d00a4cd",
-                "reference": "4758987631eaa4cce89781bffb4ae7602d00a4cd",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/7251902ebc048626aff04855c333afa9f3bae2d5",
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5",
                 "shasum": ""
             },
             "require": {
@@ -412,9 +412,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.3.5"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.7.0"
             },
-            "time": "2025-11-13T23:04:57+00:00"
+            "time": "2026-04-14T15:19:28+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",


### PR DESCRIPTION
Brings the plugin header out of "5 major versions stale" territory. Bump basis is CI-level evidence: phpunit suite (371 tests, 1008 assertions) passes against woocommerce-stubs v10.7.0, and there are no @deprecated WC API calls in includes/. Local dev install runs WC 10.3.5 without observed issues.

Composer dev constraint also bumped from ^10.3 to ^10.7 to make the new floor explicit; composer.lock follows.

Refs #32. The issue's manual smoke-test scope (HPOS, block/classic checkout, bulk invoice generation, refund -> credit note flow, order list columns) should still run against WC 10.7 in a real WP install before the next tagged release; tracking that separately rather than blocking this header sync.