### PR TITLE
Make prerelease flag conditional on tag version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
             dist/b2brouter-woocommerce-${{ steps.get_version.outputs.VERSION }}.zip.sha256
           body_path: release_notes.md
           draft: false
-          prerelease: true
+          prerelease: ${{ startsWith(github.ref, 'refs/tags/v0.') }}
           generate_release_notes: true
 
       - name: Upload artifacts


### PR DESCRIPTION
The flag was hardcoded to true, which is correct for the 0.9.x line but wrong for 1.0+ — tagging v1.0.0 today would publish the release as a GitHub pre-release, which downgrades the marketing narrative for a "first stable release" and changes how third-party tooling and the GitHub "latest release" surface treat it.

Now driven by the tag prefix:
  refs/tags/v0.* -> prerelease=true   (0.9.x, beta line)
  refs/tags/v1.* and above -> prerelease=false  (stable)

Closes #33.