### PR TITLE
Update release docs to reflect branch protection on main.

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -404,23 +404,37 @@ Update two lines:
 define('B2BROUTER_WC_VERSION', '1.1.0');
 ```
 
-#### Step 2: Commit and Push
+#### Step 2: Open a Release PR
+
+`main` is protected, so version bumps must land via pull request. Branch off main, commit the bumps, push the branch, and open a PR:
 
 ```bash
+git checkout main
+git pull --ff-only
+git checkout -b release_v1.1.0
+
 git add b2brouter-woocommerce.php
 git commit -m "Bump version to 1.1.0"
-git push origin main
+
+git push -u origin release_v1.1.0
+gh pr create --title "Release v1.1.0" --body "Version bump for 1.1.0 release."
 ```
 
-#### Step 3: Create and Push Tag
+Get the PR reviewed and merged before continuing.
+
+#### Step 3: Pull Main and Tag the Merge Commit
+
+After the PR is merged, the bumped `Version:` header lives on the merge commit on `main`. Tag that commit:
 
 ```bash
-# Create annotated tag
-git tag -a v1.1.0 -m "Release version 1.1.0"
+git checkout main
+git pull --ff-only
 
-# Push tag (triggers GitHub Actions)
+git tag -a v1.1.0 -m "Release version 1.1.0"
 git push origin v1.1.0
 ```
+
+Pushing the `v*.*.*` tag triggers GitHub Actions. The workflow validates that the tagged commit's `Version:` header matches the tag name (see `release.yml` lines 33–43), which is why the bump must be on `main` before tagging.
 
 #### Step 4: Monitor GitHub Actions
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -10,7 +10,8 @@ This document outlines the automated release process for B2Brouter for WooCommer
 - Version numbers updated in:
   - `b2brouter-woocommerce.php` (header `Version:` and constant `B2BROUTER_WC_VERSION`)
   - `README.md` (version badge)
-  - `CHANGELOG.md` (new version entry)
+  - `readme.txt` (`Stable tag`, plus new `= X.Y.Z =` blocks under `== Changelog ==` and `== Upgrade Notice ==`)
+  - `CHANGELOG.md` (new version entry and link reference at the bottom)
 
 ## Automated Release Process
 
@@ -20,7 +21,8 @@ This document outlines the automated release process for B2Brouter for WooCommer
 # Example: Releasing v1.2.3
 vim b2brouter-woocommerce.php  # Update Version: 1.2.3 and B2BROUTER_WC_VERSION
 vim README.md                   # Update version badge
-vim CHANGELOG.md               # Add new version section
+vim readme.txt                  # Update Stable tag; add = 1.2.3 = blocks under Changelog and Upgrade Notice
+vim CHANGELOG.md               # Add new version section and link reference
 ```
 
 ### 2. Run Tests
@@ -31,23 +33,42 @@ composer test
 
 Ensure all tests pass before proceeding.
 
-### 3. Commit Changes
+### 3. Create Release Branch and Open PR
+
+`main` is protected — version bumps must land via pull request. Create a release branch off `main`, commit the version bumps, push, and open a PR:
 
 ```bash
-git add b2brouter-woocommerce.php README.md CHANGELOG.md
+# Branch off the latest main
+git checkout main
+git pull --ff-only
+git checkout -b release_v1.2.3
+
+# Commit the version bumps (files updated in step 1)
+git add b2brouter-woocommerce.php README.md readme.txt CHANGELOG.md
 git commit -m "Bump version to 1.2.3"
-git push origin main
+
+# Push the branch and open a PR
+git push -u origin release_v1.2.3
+gh pr create --title "Release v1.2.3" --body "Version bump for 1.2.3 release."
 ```
 
-### 4. Create and Push Tag
+Get the PR reviewed and merged. The version bumps must end up on `main` before the next step — the release workflow validates that the **tagged commit's** `Version:` header matches the tag name (`release.yml` lines 33–43), so the merge commit's tree must carry the bumped values.
+
+### 4. Pull Main and Tag the Merge Commit
+
+After the PR is merged:
 
 ```bash
-# Create annotated tag
-git tag -a v1.2.3 -m "Release v1.2.3"
+# Sync local main with the merge commit
+git checkout main
+git pull --ff-only
 
-# Push tag to trigger GitHub Actions workflow
+# Tag the merge commit and push the tag
+git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
 ```
+
+Pushing the `v*.*.*` tag triggers `.github/workflows/release.yml`, which builds and publishes the GitHub release.
 
 ### 5. Automated Workflow Execution
 


### PR DESCRIPTION
Both DISTRIBUTION.md (sections 3-4) and DEVELOPER_GUIDE.md (steps 2-3 of the automated release section) documented pushing the version-bump commit directly to main and then tagging the local main. Branch protection on main now rejects that push, which would leave the next person to release reconstructing the correct sequence under time pressure.

The new flow:

  1. Branch off main as release_v<X.Y.Z>
  2. Commit version bumps on the branch
  3. Push branch + open PR
  4. Merge PR (so the merge commit's tree carries the bump)
  5. Pull main locally, tag the merge commit, push the tag

The release workflow's version-validation step at release.yml lines 33-43 reads Version: from the tagged commit's tree, so tagging the post-merge main commit is what makes that check pass.

Closes #34.