### PR TITLE
Revert "Bump version to 1.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to B2Brouter for WooCommerce will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-05-08
+## [Unreleased]
 
 ### Changed
 
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bulk Invoice Generation**: The "Generate B2Brouter Invoices" bulk action now enqueues background jobs via Action Scheduler instead of generating invoices synchronously. Eliminates 504 timeouts on large selections (worst case was ~12 minutes for 50 orders with auto-save PDF). Orders that already have an invoice are pre-filtered and counted as skipped. Progress and per-action logs are visible under **WooCommerce → Status → Scheduled Actions** (group `b2brouter`) (closes #37)
 - **B2Brouter PHP SDK**: Upgraded from `^1.0.0` to `^1.2.0`. The SDK now defaults to API version `2026-03-02`. Verified the only plugin-touching change in the new API version is scheme code formatting: `tin_scheme` is now sent as the zero-padded string `'9999'` instead of integer `9999` (`Invoice_Generator.php`). Removed discount/charge fields, the `taxcode` query parameter, and the `type_document` rename — none are used by the plugin (closes #35)
 - **API Key Validation**: `Settings::validate_api_key()` now uses the SDK's new `AccountService` (`$client->accounts->all()`) instead of a hand-rolled HTTP call against `/accounts`, removing duplicated header construction and response parsing
-- **Documentation**: Refreshed release docs, readme.txt, Welcome/Settings links, and wp.org screenshots ahead of the 1.0.0 release.
 
 ## [0.9.4] - 2026-04-23
 
@@ -351,7 +350,6 @@ We welcome feedback on all aspects of the plugin. Please test in a staging envir
 
 ---
 
-[1.0.0]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.0
 [0.9.4]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v0.9.4
 [0.9.3]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v0.9.3
 [0.9.2]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v0.9.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 B2Brouter for WooCommerce connects your store to B2Brouter's platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
+[![Version](https://img.shields.io/badge/version-0.9.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![WordPress](https://img.shields.io/badge/WordPress-5.8%2B-blue.svg)](https://wordpress.org)
 [![WooCommerce](https://img.shields.io/badge/WooCommerce-5.0%2B-purple.svg)](https://woocommerce.com)

--- a/b2brouter-woocommerce.php
+++ b/b2brouter-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: B2Brouter for WooCommerce
  * Plugin URI: https://b2brouter.net
  * Description: Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu), France (DGFiP), Poland (KSeF) and general EU e-invoicing.
- * Version: 1.0.0
+ * Version: 0.9.4
  * Author: B2Brouter
  * Author URI: https://b2brouter.net
  * License: MIT
@@ -24,7 +24,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('B2BROUTER_WC_VERSION', '1.0.0');
+define('B2BROUTER_WC_VERSION', '0.9.4');
 define('B2BROUTER_WC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('B2BROUTER_WC_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('B2BROUTER_WC_PLUGIN_BASENAME', plugin_basename(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, e-invoicing, peppol, verifactu, ksef
 Requires at least: 5.8
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.0
+Stable tag: 0.9.4
 License: MIT
 License URI: https://opensource.org/license/mit
 
@@ -99,19 +99,6 @@ Yes. The plugin ships with a PHPUnit test suite. See `docs/DEVELOPER_GUIDE.md` i
 
 == Changelog ==
 
-= 1.0.0 =
-
-First stable release.
-
-**Changed:**
-
-* Removed the staging/production environment selector; the plugin defaults to production. Developers can override via the `B2BROUTER_API_BASE` and `B2BROUTER_WEB_BASE` constants in `wp-config.php` (replaces the previous `B2BROUTER_DEV_API_BASE`).
-* The order meta box "View in B2Brouter" link now respects the configured web app base URL instead of being hardcoded to production.
-* Bulk invoice generation now runs as background Action Scheduler jobs instead of synchronously, eliminating 504 timeouts on large selections. Progress is visible under WooCommerce → Status → Scheduled Actions (group `b2brouter`).
-* Upgraded the B2Brouter PHP SDK to `^1.2.0` (API version `2026-03-02`). `tin_scheme` is now sent as the zero-padded string `'9999'`.
-* `Settings::validate_api_key()` now uses the SDK's `AccountService` instead of a hand-rolled HTTP call.
-* Refreshed release documentation, readme.txt, Welcome/Settings links, and wp.org screenshots ahead of the 1.0.0 release.
-
 = 0.9.4 =
 
 Final pre-release before 1.0. Focused on stability, operational polish, and preparing the plugin for distribution via the WordPress.org plugin directory and the WooCommerce Marketplace.
@@ -172,10 +159,6 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 For the complete history, see `CHANGELOG.md` in the repository.
 
 == Upgrade Notice ==
-
-= 1.0.0 =
-
-First stable release. Staging/production environment selector removed (use `B2BROUTER_API_BASE` in `wp-config.php` to override); B2Brouter PHP SDK upgraded to ^1.2.0; bulk invoice generation moved to Action Scheduler.
 
 = 0.9.4 =
 


### PR DESCRIPTION
The v1.0.0 release was published earlier today and then withdrawn because issues were found that need to be fixed before redistribution. The GitHub release and the v1.0.0 git tag have already been removed. Pull the version bump off main so the codebase no longer claims to be 1.0.0 while the fixes land. The tag will be reused for the actual 1.0.0 release once the fixes are in.

This reverts commit 751330f157b8d16b07ffd6f7aebffe8913f13587.