### PR TITLE
Migrate uninstaller to WP_Filesystem (closes #67)

### DIFF
--- a/includes/Uninstaller.php
+++ b/includes/Uninstaller.php
@@ -250,7 +250,24 @@ class Uninstaller {
             return;
         }
 
-        $this->remove_directory($path);
+        // Uninstall runs in an admin context but wp-admin/includes/file.php
+        // is only auto-loaded for some entry points, so pull it in defensively.
+        if (!function_exists('WP_Filesystem')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        if (!WP_Filesystem()) {
+            Logger::warning('B2Brouter Uninstall: WP_Filesystem API unavailable for ' . $path);
+            return;
+        }
+
+        global $wp_filesystem;
+
+        // Recursive directory delete: third arg 'd' forces the path to be
+        // treated as a directory regardless of what stat() reports.
+        if (!$wp_filesystem->delete($path, true, 'd')) {
+            Logger::warning('B2Brouter Uninstall: failed to remove directory ' . $path);
+        }
     }
 
     /**
@@ -277,42 +294,6 @@ class Uninstaller {
         }
 
         return $upload_dir['basedir'] . '/b2brouter-invoices';
-    }
-
-    /**
-     * Recursively remove a directory and all its contents.
-     *
-     * @param string $path Absolute directory path.
-     * @return void
-     */
-    protected function remove_directory($path) {
-        // @ suppresses PHP warnings at the syscall boundary; failures are
-        // surfaced through Logger::warning so leaked PDFs are visible in
-        // WooCommerce logs instead of silently dropped.
-        $entries = @scandir($path);
-        if ($entries === false) {
-            Logger::warning('B2Brouter Uninstall: scandir() failed for ' . $path);
-            return;
-        }
-
-        foreach ($entries as $entry) {
-            if ($entry === '.' || $entry === '..') {
-                continue;
-            }
-
-            $full = $path . '/' . $entry;
-            if (is_dir($full) && !is_link($full)) {
-                $this->remove_directory($full);
-            } else {
-                if (!@unlink($full)) {
-                    Logger::warning('B2Brouter Uninstall: failed to delete ' . $full);
-                }
-            }
-        }
-
-        if (!@rmdir($path)) {
-            Logger::warning('B2Brouter Uninstall: failed to remove directory ' . $path);
-        }
     }
 
     /**

--- a/tests/UninstallerTest.php
+++ b/tests/UninstallerTest.php
@@ -154,33 +154,53 @@ class UninstallerTest extends TestCase {
         $this->assertTrue(true); // no exception
     }
 
-    public function test_remove_directory_logs_warning_when_unlink_fails(): void {
-        if (DIRECTORY_SEPARATOR === '\\' || (function_exists('posix_geteuid') && posix_geteuid() === 0)) {
-            $this->markTestSkipped('Filesystem permission test requires non-root POSIX');
-        }
-
+    public function test_delete_pdf_directory_logs_warning_when_wp_filesystem_delete_fails(): void {
         mkdir($this->tmp_pdf_dir, 0777, true);
-        $blocked_file = $this->tmp_pdf_dir . '/blocked.pdf';
-        file_put_contents($blocked_file, 'cannot delete me');
-        chmod($this->tmp_pdf_dir, 0555); // r-x: prevents unlink/rmdir inside
+        file_put_contents($this->tmp_pdf_dir . '/invoice.pdf', 'fake pdf');
 
         update_option('b2brouter_pdf_storage_path', $this->tmp_pdf_dir);
         $GLOBALS['wc_logger_calls'] = array();
+        $GLOBALS['wp_filesystem_fail_methods'] = array('delete');
 
         try {
             $this->uninstaller->delete_pdf_directory();
         } finally {
-            chmod($this->tmp_pdf_dir, 0777);
-            @unlink($blocked_file);
-            @rmdir($this->tmp_pdf_dir);
+            unset($GLOBALS['wp_filesystem_fail_methods']);
         }
 
         $this->assertArrayHasKey('warning', $GLOBALS['wc_logger_calls']);
         $messages = array_column($GLOBALS['wc_logger_calls']['warning'], 'message');
-        $matched = array_filter($messages, function ($m) use ($blocked_file) {
-            return strpos($m, $blocked_file) !== false;
+        $matched = array_filter($messages, function ($m) {
+            return strpos($m, $this->tmp_pdf_dir) !== false
+                && strpos($m, 'failed to remove') !== false;
         });
-        $this->assertNotEmpty($matched, 'expected a warning mentioning the blocked file');
+        $this->assertNotEmpty($matched, 'expected a warning naming the directory whose delete failed');
+    }
+
+    public function test_delete_pdf_directory_logs_warning_when_wp_filesystem_init_fails(): void {
+        mkdir($this->tmp_pdf_dir, 0777, true);
+        file_put_contents($this->tmp_pdf_dir . '/invoice.pdf', 'fake pdf');
+
+        update_option('b2brouter_pdf_storage_path', $this->tmp_pdf_dir);
+        $GLOBALS['wc_logger_calls'] = array();
+        $GLOBALS['wp_filesystem_init_failure'] = true;
+
+        try {
+            $this->uninstaller->delete_pdf_directory();
+        } finally {
+            unset($GLOBALS['wp_filesystem_init_failure']);
+        }
+
+        $this->assertArrayHasKey('warning', $GLOBALS['wc_logger_calls']);
+        $messages = array_column($GLOBALS['wc_logger_calls']['warning'], 'message');
+        $matched = array_filter($messages, function ($m) {
+            return strpos($m, 'WP_Filesystem API unavailable') !== false;
+        });
+        $this->assertNotEmpty($matched, 'expected a warning when WP_Filesystem fails to initialize');
+
+        // PDFs should still exist on disk — uninstall is best-effort, FTP-only
+        // hosts will simply leak the cached PDFs rather than crash the deletion.
+        $this->assertTrue(is_dir($this->tmp_pdf_dir));
     }
 
     public function test_delete_options_and_transients_clears_plugin_options(): void {


### PR DESCRIPTION
Replace the manual scandir/unlink/rmdir loop in
Uninstaller::delete_pdf_directory() with a single
\$wp_filesystem->delete(\$path, true, 'd') call.

Plugin Check flags unlink() (unlink_unlink) and rmdir() (file_system_operations_rmdir) because direct PHP filesystem calls do not honour the WP_Filesystem abstraction layer, which matters on hosts that restrict direct file I/O and route writes through FTP. Routing through \$wp_filesystem keeps the uninstall portable across those hosts and clears the last two WordPress.WP.AlternativeFunctions findings on main.