### PR TITLE
Silence Plugin Check slow_db_query_meta_* warnings

### DIFF
--- a/includes/Invoice_List_Table.php
+++ b/includes/Invoice_List_Table.php
@@ -137,6 +137,7 @@ class Invoice_List_Table extends \WP_List_Table {
             'offset'     => $offset,
             'orderby'    => $orderby,
             'order'      => $order,
+            // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- listing orders by invoice meta is the page's entire purpose.
             'meta_key'   => '_b2brouter_invoice_id',
             'meta_compare' => 'EXISTS',
             'type'       => array('shop_order', 'shop_order_refund'),
@@ -147,6 +148,7 @@ class Invoice_List_Table extends \WP_List_Table {
         // Get total count for pagination
         $total_args = array(
             'limit'      => -1,
+            // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- pagination count for the listing above.
             'meta_key'   => '_b2brouter_invoice_id',
             'meta_compare' => 'EXISTS',
             'type'       => array('shop_order', 'shop_order_refund'),

--- a/includes/Status_Sync.php
+++ b/includes/Status_Sync.php
@@ -214,6 +214,7 @@ class Status_Sync {
             'limit' => $limit * 2, // Get more to filter later
             'type' => array('shop_order', 'shop_order_refund'),
             'return' => 'ids',
+            // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- finding orders with a B2Brouter invoice is the sync job's purpose; no indexed alternative without a custom table.
             'meta_query' => array(
                 array(
                     'key' => '_b2brouter_invoice_id',

--- a/includes/Uninstaller.php
+++ b/includes/Uninstaller.php
@@ -194,6 +194,7 @@ class Uninstaller {
                 'orderby'  => 'ID',
                 'order'    => 'ASC',
                 'status'   => 'any',
+                // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- one-shot meta scan at plugin deletion; no indexed alternative.
                 'meta_query' => array(
                     array(
                         'key'     => '_b2brouter_invoice_id',

--- a/includes/Webhook_Handler.php
+++ b/includes/Webhook_Handler.php
@@ -302,7 +302,9 @@ class Webhook_Handler {
         // Query orders with matching invoice ID (HPOS-compatible)
         $orders = wc_get_orders(array(
             'limit' => 1,
+            // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- webhook resolves invoice_id to order; only path without a custom invoice_id index.
             'meta_key' => '_b2brouter_invoice_id',
+            // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- paired with meta_key above.
             'meta_value' => $invoice_id,
             'return' => 'ids',
             'type' => array('shop_order', 'shop_order_refund'),


### PR DESCRIPTION
Annotate the five wc_get_orders() calls that query by _b2brouter_invoice_id with phpcs:ignore comments. Each is necessary: the list table, status sync, uninstaller, and webhook handler all need to resolve orders by their B2Brouter invoice ID, and there is no indexed alternative without introducing a custom table — out of scope for 1.0.