### PR TITLE
Prefix $autoloader in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,9 +12,9 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
     exit;
 }
 
-$autoloader = __DIR__ . '/vendor/autoload.php';
-if (file_exists($autoloader)) {
-    require_once $autoloader;
+$b2brouter_autoloader = __DIR__ . '/vendor/autoload.php';
+if (file_exists($b2brouter_autoloader)) {
+    require_once $b2brouter_autoloader;
 }
 
 if (class_exists('\\B2Brouter\\WooCommerce\\Uninstaller')) {


### PR DESCRIPTION
Plugin Check's PrefixAllGlobals rule treats top-level vars in uninstall.php as globals. Rename to $b2brouter_autoloader so the warning stops firing; uninstall.php is only ever invoked by WordPress in a closed scope, so this is purely cosmetic.