### PR TITLE
Simplify WooCommerce active check to class_exists

### DIFF
--- a/b2brouter-for-woocommerce.php
+++ b/b2brouter-for-woocommerce.php
@@ -142,7 +142,7 @@ class B2Brouter_WooCommerce {
      * @return bool True if WooCommerce is active
      */
     private function is_woocommerce_active() {
-        return class_exists('WooCommerce') || in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')));
+        return class_exists('WooCommerce');
     }
 
     /**


### PR DESCRIPTION
Drop the apply_filters('active_plugins', ...) fallback. The check runs at plugins_loaded priority 20, by which point an active and correctly-installed WooCommerce has loaded and class_exists is the authoritative answer. The fallback only mattered when WC was listed in active_plugins but its class was missing — a broken state where returning true is the wrong answer anyway, because init_plugin() then crashes on the first wc_* call. Removing it also silences the last Plugin Check warning on the shipped ZIP.