### PR TITLE
Add CNAME file for woocommerce.b2brouter.net custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+woocommerce.b2brouter.net


### PR DESCRIPTION
Sets up the custom domain configuration on the gh-pages branch. GitHub Pages reads this file to know it should serve the site from woocommerce.b2brouter.net once DNS is pointed at B2Brouter.github.io and the custom domain is configured in Settings → Pages.