### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://woocommerce.b2brouter.net/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://woocommerce.b2brouter.net/</loc>
+    <lastmod>2026-05-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- robots.txt: allow all crawlers; reference the sitemap URL.
- sitemap.xml: single entry for the canonical homepage (https://woocommerce.b2brouter.net/), the only public page on the site.