### PR TITLE
Harden PDF cache path validation in invoice operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to B2Brouter for WooCommerce will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **Hardened PDF cache path validation**: The invoice PDF cache path stored in order meta is now validated against the configured storage directory before any read, delete, or email-attach operation, preventing privileged users from coaxing the plugin into touching files outside that directory. As a defense-in-depth measure, the WooCommerce REST API can no longer write keys in the `_b2brouter_*` namespace on orders or refunds. Reported privately and coordinated with [Really Simple Plugins](https://really-simple-ssl.com/); huge thanks to their team for their assistance in making this plugin more secure, they rock.
+
 ## [1.0.3] - 2026-05-14
 
 ### Fixed

--- a/b2brouter-for-woocommerce.php
+++ b/b2brouter-for-woocommerce.php
@@ -174,6 +174,11 @@ class B2Brouter_WooCommerce {
         $this->get('status_sync');
         $this->get('webhook_handler');
 
+        // Defense-in-depth: drop any `_b2brouter_*` keys from inbound WC REST
+        // writes so privileged users (Shop Manager+) cannot poison internal
+        // order meta — notably the cached invoice PDF path.
+        $this->get('rest_meta_guard')->register();
+
         // Admin registers only admin_*, wp_ajax_*, and admin_bar hooks — skip on frontend
         if (is_admin()) {
             $this->get('admin');
@@ -281,6 +286,11 @@ class B2Brouter_WooCommerce {
                 $this->get('settings'),
                 $this->get('status_sync')
             );
+        };
+
+        // Register REST_Meta_Guard (no dependencies)
+        $this->container['rest_meta_guard'] = function() {
+            return new \B2Brouter\WooCommerce\REST_Meta_Guard();
         };
     }
 

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -211,9 +211,11 @@ class Customer {
                 </p>
 
                 <?php
-                // Show cache status if PDF is cached
-                $pdf_path = $order->get_meta('_b2brouter_invoice_pdf_path');
-                if (!empty($pdf_path) && file_exists($pdf_path)):
+                // Show cache status only when the meta-stored path resolves
+                // inside the configured storage dir; otherwise we would leak
+                // filesystem existence for attacker-supplied paths.
+                $safe_pdf_path = $this->invoice_generator->resolve_safe_pdf_path($order);
+                if ($safe_pdf_path !== null):
                     $pdf_size = $order->get_meta('_b2brouter_invoice_pdf_size');
                 ?>
                     <p class="b2brouter-pdf-info">

--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -761,6 +761,54 @@ class Invoice_Generator {
     }
 
     /**
+     * Resolve the cached invoice PDF path for an order, refusing anything
+     * that does not live inside the configured PDF storage directory.
+     *
+     * The cached path is stored in the `_b2brouter_invoice_pdf_path` order
+     * meta. That meta is writable through the WooCommerce REST API by
+     * users with `edit_shop_orders` (Shop Manager and above), so callers
+     * must treat it as untrusted: a poisoned value pointed at e.g.
+     * `wp-config.php` would otherwise be read, deleted, or attached to an
+     * outgoing email by downstream consumers. This is the single gate they
+     * all route through.
+     *
+     * @since 1.0.4
+     * @param \WC_Order $order
+     * @return string|null Absolute, realpath-resolved file path on success; null when no usable cached PDF is available.
+     */
+    public function resolve_safe_pdf_path($order) {
+        $candidate = $order->get_meta('_b2brouter_invoice_pdf_path');
+        if (empty($candidate) || !is_string($candidate)) {
+            return null;
+        }
+
+        // Only `.pdf` files are ever legitimate cache entries. Refusing
+        // other extensions defangs misconfigured storage dirs that happen
+        // to contain readable non-PDF files (e.g. a stray .htaccess).
+        if (strtolower(pathinfo($candidate, PATHINFO_EXTENSION)) !== 'pdf') {
+            return null;
+        }
+
+        $storage = $this->settings->get_pdf_storage_path();
+        $storage_real = realpath($storage);
+        $candidate_real = realpath($candidate);
+
+        if ($storage_real === false || $candidate_real === false) {
+            return null;
+        }
+
+        // Strict-prefix containment check on the realpath-resolved paths,
+        // anchored with the directory separator so `/storage` does not
+        // accidentally match `/storage-other/...`.
+        $prefix = rtrim($storage_real, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (strncmp($candidate_real, $prefix, strlen($prefix)) !== 0) {
+            return null;
+        }
+
+        return $candidate_real;
+    }
+
+    /**
      * Save invoice PDF to local storage
      *
      * @since 1.0.0
@@ -785,8 +833,8 @@ class Invoice_Generator {
             }
 
             // Check if PDF already exists and we're not forcing download
-            $existing_path = $order->get_meta('_b2brouter_invoice_pdf_path');
-            if (!$force_download && !empty($existing_path) && file_exists($existing_path)) {
+            $existing_path = $this->resolve_safe_pdf_path($order);
+            if (!$force_download && $existing_path !== null) {
                 $upload_dir = wp_upload_dir();
                 $filename = basename($existing_path);
                 $file_url = $upload_dir['baseurl'] . '/b2brouter-invoices/' . $filename;
@@ -963,10 +1011,13 @@ class Invoice_Generator {
                 );
             }
 
-            // Check if PDF exists locally
-            $pdf_path = $order->get_meta('_b2brouter_invoice_pdf_path');
+            // Check if PDF exists locally. resolve_safe_pdf_path() rejects
+            // any cached path that escapes the configured storage dir, so a
+            // poisoned `_b2brouter_invoice_pdf_path` meta cannot turn this
+            // endpoint into an arbitrary-file-read primitive.
+            $pdf_path = $this->resolve_safe_pdf_path($order);
 
-            if (!empty($pdf_path) && file_exists($pdf_path)) {
+            if ($pdf_path !== null) {
                 // Use cached PDF
                 $pdf_data = $wp_filesystem->get_contents($pdf_path);
                 $filename = basename($pdf_path);
@@ -1089,9 +1140,12 @@ class Invoice_Generator {
             return false;
         }
 
-        $pdf_path = $order->get_meta('_b2brouter_invoice_pdf_path');
+        // Containment check: refuse to delete anything that does not live
+        // inside the configured PDF storage dir, regardless of what the
+        // order meta claims.
+        $pdf_path = $this->resolve_safe_pdf_path($order);
 
-        if (empty($pdf_path) || !file_exists($pdf_path)) {
+        if ($pdf_path === null) {
             return false;
         }
 
@@ -1191,18 +1245,21 @@ class Invoice_Generator {
                 }
 
                 if (!empty($refund_invoice_id)) {
-                    $refund_pdf_path = $refund->get_meta('_b2brouter_invoice_pdf_path');
+                    $refund_pdf_path = $this->resolve_safe_pdf_path($refund);
 
-                    // If no cached PDF, try to download it
-                    if (empty($refund_pdf_path) || !file_exists($refund_pdf_path)) {
+                    // If no usable cached PDF, try to (re-)download it.
+                    if ($refund_pdf_path === null) {
                         $save_result = $this->save_invoice_pdf($refund->get_id(), false);
                         if ($save_result['success']) {
-                            $refund_pdf_path = $save_result['file_path'];
+                            // Re-resolve from meta to keep the containment
+                            // check authoritative; save_invoice_pdf has
+                            // written a fresh, trusted path back to meta.
+                            $refund = wc_get_order($refund->get_id());
+                            $refund_pdf_path = $this->resolve_safe_pdf_path($refund);
                         }
                     }
 
-                    // Add refund PDF to attachments
-                    if (!empty($refund_pdf_path) && file_exists($refund_pdf_path)) {
+                    if ($refund_pdf_path !== null) {
                         $attachments[] = $refund_pdf_path;
                     }
                 }
@@ -1212,22 +1269,24 @@ class Invoice_Generator {
         }
 
         // For other emails, attach the order's invoice PDF
-        $pdf_path = $order->get_meta('_b2brouter_invoice_pdf_path');
+        $pdf_path = $this->resolve_safe_pdf_path($order);
 
-        // If no cached PDF, try to download it temporarily
-        if (empty($pdf_path) || !file_exists($pdf_path)) {
+        // If no usable cached PDF, try to (re-)download it temporarily.
+        if ($pdf_path === null) {
             $save_result = $this->save_invoice_pdf($order->get_id(), false);
 
             if ($save_result['success']) {
-                $pdf_path = $save_result['file_path'];
+                // Re-resolve via the containment helper instead of trusting
+                // the returned file_path directly.
+                $order = wc_get_order($order->get_id());
+                $pdf_path = $this->resolve_safe_pdf_path($order);
             } else {
                 Logger::warning('B2Brouter Email Attachment: Failed to get PDF for order ' . $order->get_id());
                 return $attachments;
             }
         }
 
-        // Add PDF to attachments if it exists
-        if (!empty($pdf_path) && file_exists($pdf_path)) {
+        if ($pdf_path !== null) {
             $attachments[] = $pdf_path;
         }
 

--- a/includes/Order_Handler.php
+++ b/includes/Order_Handler.php
@@ -324,9 +324,11 @@ class Order_Handler {
                 </p>
 
                 <?php
-                // Show PDF cache status if available
-                $pdf_path = $order->get_meta('_b2brouter_invoice_pdf_path');
-                if (!empty($pdf_path) && file_exists($pdf_path)):
+                // Show PDF cache status only when the meta-stored path
+                // resolves inside the configured storage dir; otherwise we
+                // would leak filesystem existence for attacker-supplied paths.
+                $safe_pdf_path = $this->invoice_generator->resolve_safe_pdf_path($order);
+                if ($safe_pdf_path !== null):
                     $pdf_size = $order->get_meta('_b2brouter_invoice_pdf_size');
                     $pdf_date = $order->get_meta('_b2brouter_invoice_pdf_date');
                 ?>

--- a/includes/REST_Meta_Guard.php
+++ b/includes/REST_Meta_Guard.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Strip plugin-internal meta keys from inbound WooCommerce REST writes.
+ *
+ * @package B2Brouter\WooCommerce
+ * @since 1.0.4
+ */
+
+namespace B2Brouter\WooCommerce;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * REST_Meta_Guard
+ *
+ * The WooCommerce REST orders endpoint lets any user with the
+ * `edit_shop_orders` capability (Shop Manager and above) write arbitrary
+ * `meta_data` entries — including underscore-prefixed keys — on PUT
+ * /wc/v3/orders/{id}. This guard hooks WC's pre-insert filters and
+ * strips any incoming key in the `_b2brouter_*` namespace before the
+ * order is saved, so plugin-internal state (cached PDF path, invoice
+ * id, status, …) can never be poisoned through the REST surface.
+ *
+ * This is defense-in-depth alongside the path-containment check in
+ * Invoice_Generator::resolve_safe_pdf_path(); either alone would close
+ * the reported LFI, but the pair makes future regressions safer.
+ *
+ * @since 1.0.4
+ */
+class REST_Meta_Guard {
+
+    /**
+     * Namespace prefix used by every plugin-managed order meta key.
+     *
+     * @var string
+     */
+    const META_PREFIX = '_b2brouter_';
+
+    /**
+     * Register the filters with WooCommerce.
+     *
+     * @return void
+     */
+    public function register() {
+        add_filter('woocommerce_rest_pre_insert_shop_order_object', array($this, 'strip_internal_meta'), 10, 2);
+        add_filter('woocommerce_rest_pre_insert_shop_order_refund_object', array($this, 'strip_internal_meta'), 10, 2);
+    }
+
+    /**
+     * Remove any internal-namespace meta keys that the REST request tried
+     * to set, before WC persists the order.
+     *
+     * Only keys mentioned in the incoming `meta_data` payload are stripped;
+     * legitimate plugin meta already on the order is left untouched when
+     * the request does not reference it.
+     *
+     * @param mixed $order   The WC_Order / WC_Order_Refund being prepared.
+     * @param mixed $request The WP_REST_Request driving the operation.
+     * @return mixed The (possibly cleaned) order object, returned for filter chaining.
+     */
+    public function strip_internal_meta($order, $request) {
+        if (!is_object($order) || !is_object($request) || !method_exists($order, 'delete_meta_data')) {
+            return $order;
+        }
+
+        $incoming = $request->get_param('meta_data');
+        if (!is_array($incoming)) {
+            return $order;
+        }
+
+        $stripped = array();
+        foreach ($incoming as $entry) {
+            if (!is_array($entry) || !isset($entry['key']) || !is_string($entry['key'])) {
+                continue;
+            }
+            if (strncmp($entry['key'], self::META_PREFIX, strlen(self::META_PREFIX)) !== 0) {
+                continue;
+            }
+            $order->delete_meta_data($entry['key']);
+            $stripped[] = $entry['key'];
+        }
+
+        if (!empty($stripped) && class_exists(__NAMESPACE__ . '\\Logger')) {
+            Logger::warning(
+                'B2Brouter REST guard: dropped internal meta keys from inbound REST write: '
+                . implode(', ', $stripped)
+            );
+        }
+
+        return $order;
+    }
+}

--- a/tests/InvoiceGeneratorTest.php
+++ b/tests/InvoiceGeneratorTest.php
@@ -1703,4 +1703,227 @@ class InvoiceGeneratorTest extends TestCase {
         unset($wc_mock_orders[516]);
         delete_option('woocommerce_default_country');
     }
+
+    // ========== Path Containment Tests (PDF cache LFI hardening) ==========
+    //
+    // The plugin stores the absolute PDF cache path in order meta
+    // `_b2brouter_invoice_pdf_path`. Shop Manager users can poison that
+    // meta through the WooCommerce REST API (PUT /wc/v3/orders/{id} with
+    // meta_data). resolve_safe_pdf_path() is the single gate that all
+    // file-touching consumers route through so a poisoned value can never
+    // be read, deleted, or attached.
+
+    /**
+     * Helper to invoke the private resolve_safe_pdf_path method.
+     *
+     * @param WC_Order $order
+     * @return string|null
+     */
+    private function invokeResolveSafePdfPath($order) {
+        $reflection = new \ReflectionClass($this->generator);
+        $method = $reflection->getMethod('resolve_safe_pdf_path');
+        $method->setAccessible(true);
+        return $method->invoke($this->generator, $order);
+    }
+
+    /**
+     * Create an isolated PDF storage dir for a test and return its
+     * absolute, realpath-resolved path.
+     */
+    private function makeIsolatedStorage() {
+        $dir = sys_get_temp_dir() . '/b2brouter-sec-' . uniqid('', true);
+        mkdir($dir, 0700, true);
+        return realpath($dir);
+    }
+
+    /**
+     * Recursively remove a directory and its contents.
+     */
+    private function rmrf($path) {
+        if (!is_string($path) || $path === '' || !file_exists($path)) {
+            return;
+        }
+        if (is_link($path) || !is_dir($path)) {
+            @unlink($path);
+            return;
+        }
+        foreach (scandir($path) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $this->rmrf($path . '/' . $entry);
+        }
+        @rmdir($path);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_null_when_meta_empty() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        $order = new WC_Order(9001);
+
+        $this->assertNull($this->invokeResolveSafePdfPath($order));
+
+        $this->rmrf($storage);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_null_for_path_outside_storage() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        // A real, readable file that exists outside the storage dir.
+        $outside = tempnam(sys_get_temp_dir(), 'b2b-outside-') . '.pdf';
+        file_put_contents($outside, "%PDF-1.5\n%fake\n%%EOF");
+
+        $order = new WC_Order(9002);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $outside);
+
+        $this->assertNull($this->invokeResolveSafePdfPath($order));
+
+        @unlink($outside);
+        $this->rmrf($storage);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_null_for_traversal_path() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        $outside = tempnam(sys_get_temp_dir(), 'b2b-traverse-') . '.pdf';
+        file_put_contents($outside, "%PDF-1.5\n%fake\n%%EOF");
+
+        // Build a traversal path that lexically starts under $storage but
+        // resolves outside it via `..`.
+        $traversal = $storage . '/../' . basename($outside);
+
+        $order = new WC_Order(9003);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $traversal);
+
+        $this->assertNull($this->invokeResolveSafePdfPath($order));
+
+        @unlink($outside);
+        $this->rmrf($storage);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_null_for_nonexistent_path() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        $order = new WC_Order(9004);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $storage . '/does-not-exist.pdf');
+
+        $this->assertNull($this->invokeResolveSafePdfPath($order));
+
+        $this->rmrf($storage);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_null_for_non_pdf_extension() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        // A non-PDF file living inside the storage dir (e.g. a stray .txt or
+        // a config file the host left behind). We still refuse to stream it.
+        $non_pdf = $storage . '/not-a-pdf.txt';
+        file_put_contents($non_pdf, 'secret');
+
+        $order = new WC_Order(9005);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $non_pdf);
+
+        $this->assertNull($this->invokeResolveSafePdfPath($order));
+
+        $this->rmrf($storage);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_absolute_path_for_legit_pdf_in_storage() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        $pdf = $storage . '/invoice-order-1-1.pdf';
+        file_put_contents($pdf, "%PDF-1.5\n%legit\n%%EOF");
+
+        $order = new WC_Order(9006);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $pdf);
+
+        $resolved = $this->invokeResolveSafePdfPath($order);
+        $this->assertSame(realpath($pdf), $resolved);
+
+        $this->rmrf($storage);
+    }
+
+    public function test_resolve_safe_pdf_path_returns_null_for_symlink_pointing_outside_storage() {
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        $outside = tempnam(sys_get_temp_dir(), 'b2b-symlink-target-') . '.pdf';
+        file_put_contents($outside, "%PDF-1.5\n%target\n%%EOF");
+
+        $link = $storage . '/looks-inside.pdf';
+        if (!@symlink($outside, $link)) {
+            $this->markTestSkipped('symlink() unavailable on this platform.');
+        }
+
+        $order = new WC_Order(9007);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $link);
+
+        $this->assertNull($this->invokeResolveSafePdfPath($order));
+
+        @unlink($link);
+        @unlink($outside);
+        $this->rmrf($storage);
+    }
+
+    // ========== Regression: file-touching consumers refuse poisoned paths ==========
+
+    public function test_delete_invoice_pdf_refuses_to_delete_file_outside_storage() {
+        global $wc_mock_orders;
+
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+
+        $outside = tempnam(sys_get_temp_dir(), 'b2b-delete-target-') . '.pdf';
+        file_put_contents($outside, "should not be deleted");
+
+        $order = new WC_Order(9100);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $outside);
+        $wc_mock_orders[9100] = $order;
+
+        $result = $this->generator->delete_invoice_pdf(9100);
+
+        $this->assertFalse($result, 'delete_invoice_pdf must refuse to act on poisoned meta path');
+        $this->assertFileExists($outside, 'file outside storage must not be deleted');
+
+        unset($wc_mock_orders[9100]);
+        @unlink($outside);
+        $this->rmrf($storage);
+    }
+
+    public function test_attach_pdf_to_email_skips_attachment_when_meta_path_is_poisoned() {
+        global $wc_mock_orders;
+
+        $storage = $this->makeIsolatedStorage();
+        $this->mock_settings->method('get_pdf_storage_path')->willReturn($storage);
+        $this->mock_settings->method('get_attach_to_order_completed')->willReturn(true);
+
+        $outside = tempnam(sys_get_temp_dir(), 'b2b-attach-target-') . '.pdf';
+        file_put_contents($outside, "%PDF-1.5\n%secret\n%%EOF");
+
+        $order = new WC_Order(9101);
+        $order->add_meta_data('_b2brouter_invoice_id', 'inv-test', true);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', $outside);
+        $wc_mock_orders[9101] = $order;
+
+        // Inject mock client so the fallback save path can be exercised
+        // without trying a real HTTP call. With no API key configured,
+        // save_invoice_pdf will fail and the attachment must remain absent.
+        $attachments = $this->generator->attach_pdf_to_email(array(), 'customer_completed_order', $order);
+
+        $this->assertNotContains(
+            $outside,
+            $attachments,
+            'attach_pdf_to_email must not attach a file outside the storage dir'
+        );
+
+        unset($wc_mock_orders[9101]);
+        @unlink($outside);
+        $this->rmrf($storage);
+    }
 }

--- a/tests/RESTMetaGuardTest.php
+++ b/tests/RESTMetaGuardTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests for REST_Meta_Guard.
+ *
+ * @package B2Brouter\WooCommerce\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+use B2Brouter\WooCommerce\REST_Meta_Guard;
+
+/**
+ * Defense-in-depth filter that strips any `_b2brouter_*` keys from the
+ * `meta_data` array on inbound WooCommerce REST writes. This prevents a
+ * Shop Manager (who has `edit_shop_orders` and can therefore PUT orders
+ * via the REST API) from poisoning plugin-internal meta — most critically
+ * the cached PDF path consumed by Invoice_Generator.
+ */
+class RESTMetaGuardTest extends TestCase {
+
+    /**
+     * Build a stub object that exposes get_param() the way WP_REST_Request
+     * does, returning the provided meta_data for the 'meta_data' param.
+     */
+    private function fakeRequest(array $meta_data) {
+        return new class($meta_data) {
+            private $params;
+            public function __construct($meta_data) {
+                $this->params = array('meta_data' => $meta_data);
+            }
+            public function get_param($key) {
+                return isset($this->params[$key]) ? $this->params[$key] : null;
+            }
+        };
+    }
+
+    public function test_strips_invoice_pdf_path_from_meta_data() {
+        $order = new WC_Order(7001);
+        // Simulate WC having already applied the inbound meta_data to the
+        // order object before our filter runs.
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', '/etc/passwd');
+
+        $request = $this->fakeRequest(array(
+            array('key' => '_b2brouter_invoice_pdf_path', 'value' => '/etc/passwd'),
+        ));
+
+        $guard = new REST_Meta_Guard();
+        $result = $guard->strip_internal_meta($order, $request);
+
+        $this->assertSame('', $result->get_meta('_b2brouter_invoice_pdf_path'));
+    }
+
+    public function test_strips_every_internal_namespace_key() {
+        $order = new WC_Order(7002);
+        $order->update_meta_data('_b2brouter_invoice_id', 'attacker-set');
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', '/etc/passwd');
+        $order->update_meta_data('_b2brouter_invoice_status', 'sent');
+
+        $request = $this->fakeRequest(array(
+            array('key' => '_b2brouter_invoice_id', 'value' => 'attacker-set'),
+            array('key' => '_b2brouter_invoice_pdf_path', 'value' => '/etc/passwd'),
+            array('key' => '_b2brouter_invoice_status', 'value' => 'sent'),
+        ));
+
+        $guard = new REST_Meta_Guard();
+        $guard->strip_internal_meta($order, $request);
+
+        $this->assertSame('', $order->get_meta('_b2brouter_invoice_id'));
+        $this->assertSame('', $order->get_meta('_b2brouter_invoice_pdf_path'));
+        $this->assertSame('', $order->get_meta('_b2brouter_invoice_status'));
+    }
+
+    public function test_does_not_touch_non_internal_meta() {
+        $order = new WC_Order(7003);
+        $order->update_meta_data('_some_other_plugin_key', 'keep me');
+        $order->update_meta_data('public_meta', 'keep me too');
+
+        $request = $this->fakeRequest(array(
+            array('key' => '_some_other_plugin_key', 'value' => 'keep me'),
+            array('key' => 'public_meta', 'value' => 'keep me too'),
+        ));
+
+        $guard = new REST_Meta_Guard();
+        $guard->strip_internal_meta($order, $request);
+
+        $this->assertSame('keep me', $order->get_meta('_some_other_plugin_key'));
+        $this->assertSame('keep me too', $order->get_meta('public_meta'));
+    }
+
+    public function test_leaves_internal_meta_alone_when_request_did_not_touch_it() {
+        // The filter only strips keys mentioned in the inbound payload. A
+        // REST write that touches unrelated fields must not wipe legitimate
+        // plugin meta off the order.
+        $order = new WC_Order(7004);
+        $order->update_meta_data('_b2brouter_invoice_id', 'inv-legit-123');
+
+        $request = $this->fakeRequest(array(
+            array('key' => 'public_meta', 'value' => 'whatever'),
+        ));
+
+        $guard = new REST_Meta_Guard();
+        $guard->strip_internal_meta($order, $request);
+
+        $this->assertSame('inv-legit-123', $order->get_meta('_b2brouter_invoice_id'));
+    }
+
+    public function test_tolerates_missing_meta_data_param() {
+        $order = new WC_Order(7005);
+
+        $request = new class {
+            public function get_param($key) {
+                return null;
+            }
+        };
+
+        $guard = new REST_Meta_Guard();
+        $result = $guard->strip_internal_meta($order, $request);
+
+        $this->assertSame($order, $result);
+    }
+
+    public function test_tolerates_malformed_meta_entries() {
+        $order = new WC_Order(7006);
+        $order->update_meta_data('_b2brouter_invoice_pdf_path', '/etc/passwd');
+
+        $request = $this->fakeRequest(array(
+            'not-an-array',
+            array(),
+            array('value' => 'no-key-field'),
+            array('key' => 12345, 'value' => 'numeric-key'),
+            array('key' => '_b2brouter_invoice_pdf_path', 'value' => '/etc/passwd'),
+        ));
+
+        $guard = new REST_Meta_Guard();
+        // Should not throw; valid entries should still be stripped.
+        $guard->strip_internal_meta($order, $request);
+
+        $this->assertSame('', $order->get_meta('_b2brouter_invoice_pdf_path'));
+    }
+}


### PR DESCRIPTION
The invoice PDF cache path is stored in `_b2brouter_invoice_pdf_path` order meta. Shop Manager users can write that meta through the WooCommerce REST API, and the file-touching consumers (`stream_invoice_pdf`, `delete_invoice_pdf`,
`attach_pdf_to_email`, the cached-PDF short-circuit in `save_invoice_pdf`, plus the admin/customer metabox displays) trusted it without containment checks — yielding an authenticated arbitrary-file read, arbitrary-file deletion, and file-attachment exfiltration vector. A new `Invoice_Generator::resolve_safe_pdf_path()` realpath-validates the cached path against the configured storage dir and is now the single gate every consumer routes through. A defense-in-depth `REST_Meta_Guard` additionally strips any `_b2brouter_*` keys from inbound WC REST `meta_data` on orders and refunds so the meta cannot be poisoned in the first place.