### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to B2Brouter for WooCommerce will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.4] - 2026-05-22
 
 ### Security
 

--- a/b2brouter-for-woocommerce.php
+++ b/b2brouter-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: B2Brouter for WooCommerce
  * Plugin URI: https://www.b2brouter.net/docs/#/en/integration/woocommerce
  * Description: Electronic invoicing for WooCommerce. Compliance for Spain (Verifactu), France (DGFiP), Poland (KSeF) and general EU e-invoicing.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: B2Brouter
  * Author URI: https://b2brouter.net
  * License: MIT
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('B2BROUTER_WC_VERSION', '1.0.3');
+define('B2BROUTER_WC_VERSION', '1.0.4');
 define('B2BROUTER_WC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('B2BROUTER_WC_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('B2BROUTER_WC_PLUGIN_BASENAME', plugin_basename(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, e-invoicing, peppol, verifactu, ksef
 Requires at least: 5.8
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: MIT
 License URI: https://opensource.org/license/mit
 
@@ -121,6 +121,12 @@ This plugin connects your WooCommerce store to **B2Brouter**, a third-party e-in
 
 == Changelog ==
 
+= 1.0.4 =
+
+**Security:**
+
+* Hardened invoice PDF cache path validation so privileged users can no longer coax the plugin into reading, deleting, or email-attaching files outside the configured PDF storage directory. The WooCommerce REST API can no longer write keys in the `_b2brouter_*` namespace on orders or refunds. Reported privately and coordinated with [Really Simple Plugins](https://really-simple-ssl.com/); huge thanks to their team.
+
 = 1.0.3 =
 
 **Fixed:**
@@ -228,6 +234,10 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 For the complete history, see `CHANGELOG.md` in the repository.
 
 == Upgrade Notice ==
+
+= 1.0.4 =
+
+Security release. Hardens invoice PDF cache path validation and stops the WooCommerce REST API from writing internal `_b2brouter_*` order meta. All sites should upgrade.
 
 = 1.0.3 =
 


### PR DESCRIPTION
Security release: the path-containment and REST-meta guards merged in PR #94 are now shipped to users. CHANGELOG promotes the Unreleased section to 1.0.4 and readme.txt picks up matching Changelog and Upgrade Notice entries for the WordPress.org listing.