### PR TITLE
Complete 1.0.4 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,7 @@ We welcome feedback on all aspects of the plugin. Please test in a staging envir
 
 ---
 
+[1.0.4]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.4
 [1.0.3]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.3
 [1.0.2]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.2
 [1.0.1]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 B2Brouter for WooCommerce connects your store to B2Brouter's platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
-[![Version](https://img.shields.io/badge/version-1.0.3-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
+[![Version](https://img.shields.io/badge/version-1.0.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![WordPress](https://img.shields.io/badge/WordPress-5.8%2B-blue.svg)](https://wordpress.org)
 [![WooCommerce](https://img.shields.io/badge/WooCommerce-5.0%2B-purple.svg)](https://woocommerce.com)


### PR DESCRIPTION
PR #95 missed two items from the DISTRIBUTION.md release checklist: the README.md version badge still read 1.0.3, and CHANGELOG.md had no link reference for [1.0.4] at the bottom. Fixing both before tagging so main matches the documented release-prep state every prior version has shipped with.