### PR TITLE
Bump b2brouter-php to 1.3.0 and migrate refund payload to API 2026-04-20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "b2brouter/b2brouter-php": "^1.2.0"
+        "b2brouter/b2brouter-php": "^1.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62164999f68c81e0aa96b37f7250bbcb",
+    "content-hash": "9a30809bb611b4882c9c64c720a1425d",
     "packages": [
         {
             "name": "b2brouter/b2brouter-php",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/B2Brouter/b2brouter-php.git",
-                "reference": "81146e0cc81468d8e250c293ed5b006e35dd7d77"
+                "reference": "37a1c9c763664c6de2898eb4819e6b0034830acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/B2Brouter/b2brouter-php/zipball/81146e0cc81468d8e250c293ed5b006e35dd7d77",
-                "reference": "81146e0cc81468d8e250c293ed5b006e35dd7d77",
+                "url": "https://api.github.com/repos/B2Brouter/b2brouter-php/zipball/37a1c9c763664c6de2898eb4819e6b0034830acc",
+                "reference": "37a1c9c763664c6de2898eb4819e6b0034830acc",
                 "shasum": ""
             },
             "require": {
@@ -60,9 +60,9 @@
             ],
             "support": {
                 "issues": "https://github.com/B2Brouter/b2brouter-php/issues",
-                "source": "https://github.com/B2Brouter/b2brouter-php/tree/v1.2.0"
+                "source": "https://github.com/B2Brouter/b2brouter-php/tree/v1.3.0"
             },
-            "time": "2026-03-26T08:49:57+00:00"
+            "time": "2026-05-25T10:22:36+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -508,24 +508,25 @@ class Invoice_Generator {
 
         // Add refund-specific fields
         if ($is_refund && $parent_invoice_info) {
-            // Add amended invoice reference
-            $invoice_data['amended_number'] = $parent_invoice_info['invoice_number'];
+            $reference = [
+                'reference_type' => 'amend',
+                'number'         => $parent_invoice_info['invoice_number'],
+            ];
 
-            // Parse invoice date (format: Y-m-d)
             $invoice_date = $parent_invoice_info['invoice_date'];
             if (!empty($invoice_date)) {
-                // Convert MySQL datetime to Y-m-d format
                 $date_obj = new \DateTime($invoice_date);
-                $invoice_data['amended_date'] = $date_obj->format('Y-m-d');
+                $reference['date'] = $date_obj->format('Y-m-d');
             }
 
-            // Add refund reason if available
             if (method_exists($order, 'get_reason') && !empty($order->get_reason())) {
-                $invoice_data['amended_reason'] = $order->get_reason();
+                $reference['reason'] = $order->get_reason();
             }
 
-            // Add is_credit_note flag for non-rectificative countries
-            // This is an undocumented parameter used by B2Brouter API
+            $invoice_data['invoice_references'] = [$reference];
+
+            // Undocumented parameter signalling that the document is a credit note
+            // (positive amounts) rather than a rectificative invoice (negative amounts).
             if (!$is_rectificative) {
                 $invoice_data['is_credit_note'] = true;
             }

--- a/tests/InvoiceTypesTest.php
+++ b/tests/InvoiceTypesTest.php
@@ -221,13 +221,20 @@ class InvoiceTypesTest extends TestCase {
         $prepare_method->setAccessible(true);
         $invoice_data = $prepare_method->invoke($this->invoice_generator, $mock_refund);
 
-        // Assert amended fields are set
-        $this->assertArrayHasKey('amended_number', $invoice_data);
-        $this->assertEquals('INV-ES-2025-00100', $invoice_data['amended_number']);
-        $this->assertArrayHasKey('amended_date', $invoice_data);
-        $this->assertEquals('2025-11-20', $invoice_data['amended_date']);
-        $this->assertArrayHasKey('amended_reason', $invoice_data);
-        $this->assertEquals('Customer requested refund', $invoice_data['amended_reason']);
+        // Assert legacy top-level amend fields are absent (API 2026-04-20)
+        $this->assertArrayNotHasKey('amended_number', $invoice_data);
+        $this->assertArrayNotHasKey('amended_date', $invoice_data);
+        $this->assertArrayNotHasKey('amended_reason', $invoice_data);
+        $this->assertArrayNotHasKey('amend_reason', $invoice_data);
+
+        // Assert structured invoice_references[] entry
+        $this->assertArrayHasKey('invoice_references', $invoice_data);
+        $this->assertCount(1, $invoice_data['invoice_references']);
+        $reference = $invoice_data['invoice_references'][0];
+        $this->assertEquals('amend', $reference['reference_type']);
+        $this->assertEquals('INV-ES-2025-00100', $reference['number']);
+        $this->assertEquals('2025-11-20', $reference['date']);
+        $this->assertEquals('Customer requested refund', $reference['reason']);
 
         // Assert is_credit_note is NOT set (Spain uses rectificative)
         $this->assertArrayNotHasKey('is_credit_note', $invoice_data);
@@ -286,11 +293,20 @@ class InvoiceTypesTest extends TestCase {
         $prepare_method->setAccessible(true);
         $invoice_data = $prepare_method->invoke($this->invoice_generator, $mock_refund);
 
-        // Assert amended fields are set
-        $this->assertArrayHasKey('amended_number', $invoice_data);
-        $this->assertEquals('INV-US-2025-00200', $invoice_data['amended_number']);
-        $this->assertArrayHasKey('amended_date', $invoice_data);
-        $this->assertArrayHasKey('amended_reason', $invoice_data);
+        // Assert legacy top-level amend fields are absent (API 2026-04-20)
+        $this->assertArrayNotHasKey('amended_number', $invoice_data);
+        $this->assertArrayNotHasKey('amended_date', $invoice_data);
+        $this->assertArrayNotHasKey('amended_reason', $invoice_data);
+        $this->assertArrayNotHasKey('amend_reason', $invoice_data);
+
+        // Assert structured invoice_references[] entry
+        $this->assertArrayHasKey('invoice_references', $invoice_data);
+        $this->assertCount(1, $invoice_data['invoice_references']);
+        $reference = $invoice_data['invoice_references'][0];
+        $this->assertEquals('amend', $reference['reference_type']);
+        $this->assertEquals('INV-US-2025-00200', $reference['number']);
+        $this->assertArrayHasKey('date', $reference);
+        $this->assertEquals('Defective product', $reference['reason']);
 
         // Assert is_credit_note IS set (non-Spain)
         $this->assertArrayHasKey('is_credit_note', $invoice_data);


### PR DESCRIPTION
Closes #98.

- Bumps the bundled `b2brouter-php` SDK constraint from `^1.2.0` to `^1.3.0`.
- Lets the SDK's new default API version (`2026-04-20`) flow through; no  explicit `api_version` pin is added.
- Rewrites the refund branch in `Invoice_Generator::prepare_invoice_data()` to emit the new structured `invoice_references[]` array (with  `reference_type: 'amend'`) in place of the flat top-level amend fields  (`amended_number`, `amended_date`, `amend_reason`), which were dropped from `POST /invoices` in API 2026-04-20.
- Resolves a pre-existing latent bug along the way: the refund-reason key was being emitted as `amended_reason` (with an extra `d`), which no API version has ever accepted.Rails strong-params has been silently dropping it on every release. The new shape uses `reason`  inside the reference object, so the refund reason now actually reaches the backend.