### PR TITLE
Identify the plugin in outbound requests via SDK app_info

### DIFF
--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -115,7 +115,7 @@ class Invoice_Generator {
 
         // Create client with environment setting
         $options = array('api_base' => $this->settings->get_api_base_url());
-        $this->client = new \B2BRouter\B2BRouterClient($api_key, $options);
+        $this->client = Sdk_Client_Factory::build($api_key, $options);
 
         return $this->client;
     }

--- a/includes/Sdk_Client_Factory.php
+++ b/includes/Sdk_Client_Factory.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * B2Brouter SDK Client Factory
+ *
+ * @package B2Brouter\WooCommerce
+ * @since 1.0.5
+ */
+
+namespace B2Brouter\WooCommerce;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Builds B2BRouterClient instances with shared plugin defaults.
+ *
+ * Centralises the SDK options that every call site in the plugin needs to
+ * share — notably the `app_info` descriptor that identifies the plugin in
+ * outbound requests via the User-Agent header. Callers pass their own
+ * per-context options (api_base, http_client, timeout, ...); those win over
+ * defaults so individual call sites can still override anything.
+ *
+ * @since 1.0.5
+ */
+class Sdk_Client_Factory {
+
+    /**
+     * Build a B2BRouterClient with plugin defaults merged in.
+     *
+     * @param string $api_key The B2Brouter API key.
+     * @param array  $options Per-caller SDK options; override any default.
+     * @return \B2BRouter\B2BRouterClient
+     */
+    public static function build($api_key, array $options = array()) {
+        $options = array_merge(self::default_options(), $options);
+        return new \B2BRouter\B2BRouterClient($api_key, $options);
+    }
+
+    /**
+     * Default SDK options injected on every build.
+     *
+     * @return array
+     */
+    public static function default_options() {
+        return array(
+            'app_info' => self::default_app_info(),
+        );
+    }
+
+    /**
+     * Plugin descriptor appended to the SDK User-Agent.
+     *
+     * Reads B2BROUTER_WC_VERSION and home_url() defensively so the factory
+     * also works in environments where the plugin bootstrap or WordPress
+     * itself is not loaded (most notably the unit-test harness).
+     *
+     * @return array
+     */
+    public static function default_app_info() {
+        $app_info = array('name' => 'B2BRouter-WooCommerce');
+
+        if (defined('B2BROUTER_WC_VERSION')) {
+            $app_info['version'] = B2BROUTER_WC_VERSION;
+        }
+
+        if (function_exists('home_url')) {
+            $url = \home_url();
+            if (is_string($url) && $url !== '') {
+                $app_info['url'] = $url;
+            }
+        }
+
+        return $app_info;
+    }
+}

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -366,7 +366,7 @@ class Settings {
      * @return \B2BRouter\B2BRouterClient
      */
     protected function build_b2brouter_client($api_key, array $options) {
-        return new \B2BRouter\B2BRouterClient($api_key, $options);
+        return Sdk_Client_Factory::build($api_key, $options);
     }
 
     /**

--- a/includes/Status_Sync.php
+++ b/includes/Status_Sync.php
@@ -478,7 +478,7 @@ class Status_Sync {
         }
 
         $options = array('api_base' => $this->settings->get_api_base_url());
-        return new \B2BRouter\B2BRouterClient($api_key, $options);
+        return Sdk_Client_Factory::build($api_key, $options);
     }
 
     /**

--- a/tests/SdkClientFactoryTest.php
+++ b/tests/SdkClientFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for Sdk_Client_Factory
+ *
+ * @package B2Brouter\WooCommerce\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+use B2Brouter\WooCommerce\Sdk_Client_Factory;
+
+/**
+ * Sdk_Client_Factory test case
+ *
+ * @since 1.0.5
+ */
+class SdkClientFactoryTest extends TestCase {
+
+    /**
+     * @return void
+     */
+    public function test_default_app_info_uses_plugin_name_and_version() {
+        $app_info = Sdk_Client_Factory::default_app_info();
+
+        $this->assertSame('B2BRouter-WooCommerce', $app_info['name']);
+        $this->assertSame(B2BROUTER_WC_VERSION, $app_info['version']);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_default_app_info_omits_url_when_home_url_unavailable() {
+        // Bootstrap does not define home_url(); the factory must not synthesise one.
+        $app_info = Sdk_Client_Factory::default_app_info();
+
+        $this->assertArrayNotHasKey('url', $app_info);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_build_injects_app_info_into_user_agent() {
+        $client = Sdk_Client_Factory::build('test-key');
+
+        $user_agent = $client->getUserAgent();
+
+        $this->assertStringContainsString('B2BRouter-PHP/', $user_agent);
+        $this->assertStringContainsString(
+            'B2BRouter-WooCommerce/' . B2BROUTER_WC_VERSION,
+            $user_agent
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function test_caller_app_info_overrides_defaults() {
+        $client = Sdk_Client_Factory::build('test-key', array(
+            'app_info' => array(
+                'name'    => 'Custom-Caller',
+                'version' => '9.9.9',
+            ),
+        ));
+
+        $user_agent = $client->getUserAgent();
+
+        $this->assertStringContainsString('Custom-Caller/9.9.9', $user_agent);
+        $this->assertStringNotContainsString('B2BRouter-WooCommerce', $user_agent);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_caller_options_pass_through() {
+        $client = Sdk_Client_Factory::build('test-key', array(
+            'api_base' => 'https://example.test',
+        ));
+
+        $this->assertSame('https://example.test', $client->getApiBase());
+    }
+}


### PR DESCRIPTION
Routes every B2BRouterClient construction through a new Sdk_Client_Factory that injects an app_info descriptor (name=B2BRouter-WooCommerce, version=B2BROUTER_WC_VERSION, url=home_url()) so requests originating from the plugin are distinguishable from raw SDK calls in B2BRouter's server logs and support cases.

The factory owns the shared default options across the three existing call sites (Settings, Status_Sync, Invoice_Generator) to prevent drift as new ones appear, while still letting any caller-supplied options win when explicitly passed.

Refs #97.