### PR TITLE
Complete 1.0.5 release surfaces missed in 81f97e8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,6 +412,7 @@ We welcome feedback on all aspects of the plugin. Please test in a staging envir
 
 ---
 
+[1.0.5]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.5
 [1.0.4]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.4
 [1.0.3]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.3
 [1.0.2]: https://github.com/B2Brouter/b2brouter-woocommerce/releases/tag/v1.0.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 B2Brouter for WooCommerce connects your store to B2Brouter's platform: structured invoice data, electronic delivery, and country-specific tax authority reporting where required.
 
-[![Version](https://img.shields.io/badge/version-1.0.4-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
+[![Version](https://img.shields.io/badge/version-1.0.5-blue.svg)](https://github.com/B2Brouter/b2brouter-woocommerce/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![WordPress](https://img.shields.io/badge/WordPress-5.8%2B-blue.svg)](https://wordpress.org)
 [![WooCommerce](https://img.shields.io/badge/WooCommerce-5.0%2B-purple.svg)](https://woocommerce.com)

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,14 @@ This plugin connects your WooCommerce store to **B2Brouter**, a third-party e-in
 
 == Changelog ==
 
+= 1.0.5 =
+
+**Changed:**
+
+* B2Brouter PHP SDK upgraded from 1.2 to 1.3. Default API version is now `2026-04-20`. The plugin's refund / credit-note payload migrates from the flat top-level amend fields to the new structured `invoice_references[]` array. Resolves a long-standing latent bug along the way: the refund reason was being emitted as `amended_reason` (extra `d`), which no API version has ever accepted — Rails strong-params had been silently dropping it on every release. The new payload places the reason inside the reference object, so the refund reason now actually reaches the backend.
+* Outbound API requests now identify the plugin in their `User-Agent` header via the SDK's `app_info` option, making plugin-originated calls distinguishable from raw SDK calls in B2Brouter's server logs.
+* Tested against WordPress 7.0 "Armstrong" with WooCommerce 10.7.
+
 = 1.0.4 =
 
 **Security:**
@@ -234,6 +242,10 @@ Final pre-release before 1.0. Focused on stability, operational polish, and prep
 For the complete history, see `CHANGELOG.md` in the repository.
 
 == Upgrade Notice ==
+
+= 1.0.5 =
+
+Bumps the bundled B2Brouter PHP SDK to v1.3 (API version `2026-04-20`) and migrates the refund payload to the new `invoice_references[]` shape. Adds plugin self-identification to the outbound `User-Agent` header. Tested up to WordPress 7.0.
 
 = 1.0.4 =
 


### PR DESCRIPTION
The previous release-prep commit (81f97e8 "Prepare 1.0.5 release") bumped the plugin entry, readme.txt Stable tag, and CHANGELOG.md section header, but missed four other release-prep items the docs/DISTRIBUTION.md step-1 checklist calls for: README.md version badge, readme.txt Changelog block, readme.txt Upgrade Notice block, and the CHANGELOG.md link reference for 1.0.5.

The two readme.txt blocks are user-facing on the wp.org plugin page (Changelog tab and admin update notice); fixing them before tagging keeps the wp.org listing accurate from the moment 1.0.5 lands.