### PR TITLE
Include item meta in invoice line descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to B2Brouter for WooCommerce will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Item options on invoice lines**: Invoice line descriptions now include the customer-visible item meta — WooCommerce variation attributes and the options added by product add-on / extra-option plugins (Product Add-Ons, YITH, Extra Product Options, etc.) — appended under the product name as `Label: value` lines. Previously the line carried only the product name, so the invoice didn't reflect the variation or options the customer actually paid for. Built on WooCommerce's own `get_formatted_meta_data()` formatter, so private (`_`-prefixed) meta stays hidden, values already in the product name aren't duplicated, and the `woocommerce_order_item_display_meta_*` filters other plugins hook are honoured. Verified end-to-end against staging (closes #105)
+
 ## [1.0.5] - 2026-05-25
 
 ### Changed

--- a/includes/Invoice_Generator.php
+++ b/includes/Invoice_Generator.php
@@ -394,7 +394,7 @@ class Invoice_Generator {
             }
 
             $line = array(
-                'description' => $item->get_name(),
+                'description' => $this->build_line_description($item),
                 'quantity' => $quantity,
                 'price' => $price,
             );
@@ -533,6 +533,41 @@ class Invoice_Generator {
         }
 
         return $invoice_data;
+    }
+
+    /**
+     * Build the invoice line description for an order item.
+     *
+     * Starts from the product name and appends any customer-visible item meta
+     * — WooCommerce-core variation attributes and the options that add-on /
+     * extra-option plugins store as item meta — using WooCommerce's own
+     * formatter. With $include_all = false, meta whose value is already part of
+     * the product name is skipped (so variations aren't duplicated); private
+     * `_`-prefixed meta is excluded; and the `woocommerce_order_item_display_meta_*`
+     * filters that those plugins hook are honoured. Each entry is rendered on
+     * its own line as "Label: value", tag-stripped for plain-text output.
+     *
+     * @since 1.0.6
+     * @param \WC_Order_Item_Product $item The order item.
+     * @return string The line description.
+     */
+    private function build_line_description($item) {
+        $description = $item->get_name();
+
+        if (!method_exists($item, 'get_formatted_meta_data')) {
+            return $description;
+        }
+
+        foreach ((array) $item->get_formatted_meta_data('_', false) as $meta) {
+            $key   = trim(wp_strip_all_tags($meta->display_key, true));
+            $value = trim(wp_strip_all_tags($meta->display_value, true));
+            if ($key === '' && $value === '') {
+                continue;
+            }
+            $description .= "\n" . $key . ': ' . $value;
+        }
+
+        return $description;
     }
 
     /**

--- a/tests/InvoiceTypesTest.php
+++ b/tests/InvoiceTypesTest.php
@@ -397,4 +397,101 @@ class InvoiceTypesTest extends TestCase {
         $mock_order_with_tin->method('get_meta')->willReturn('ES12345678');
         $this->assertEquals('IssuedInvoice', $method->invoke($this->invoice_generator, $mock_order_with_tin));
     }
+
+    /**
+     * Build a single-item order around the given item, for line-description
+     * tests. Uses the real WC_Order_Item_Product mock so its formatted-meta
+     * behaviour is exercised.
+     *
+     * @param \WC_Order_Item_Product $item The order item.
+     * @return \WC_Order Mock order.
+     */
+    private function make_order_with_item($item) {
+        $order = $this->createMock(\WC_Order::class);
+        $order->method('get_type')->willReturn('shop_order');
+        $order->method('get_billing_first_name')->willReturn('Pat');
+        $order->method('get_billing_last_name')->willReturn('Buyer');
+        $order->method('get_billing_email')->willReturn('pat@example.com');
+        $order->method('get_billing_country')->willReturn('ES');
+        $order->method('get_billing_address_1')->willReturn('Carrer de Test 1');
+        $order->method('get_billing_address_2')->willReturn('');
+        $order->method('get_billing_city')->willReturn('Barcelona');
+        $order->method('get_billing_postcode')->willReturn('08001');
+        $order->method('get_billing_company')->willReturn('');
+        $order->method('get_currency')->willReturn('EUR');
+        $order->method('get_id')->willReturn(950);
+        $order->method('get_order_number')->willReturn('950');
+        $order->method('get_items')->willReturn(array($item));
+        $order->method('get_shipping_total')->willReturn(0);
+        $order->method('get_meta')->willReturn('');
+        $order->method('get_item_subtotal')->willReturn(10.00);
+
+        return $order;
+    }
+
+    /**
+     * Read the first invoice line's description for the given order.
+     *
+     * @param \WC_Order $order Mock order.
+     * @return string
+     */
+    private function first_line_description($order) {
+        $reflection = new \ReflectionClass($this->invoice_generator);
+        $method = $reflection->getMethod('prepare_invoice_data');
+        $method->setAccessible(true);
+        $invoice_data = $method->invoke($this->invoice_generator, $order);
+        return $invoice_data['invoice_lines_attributes'][0]['description'];
+    }
+
+    /**
+     * Customer-visible item meta (variation attributes, product add-on /
+     * extra-option selections) must be appended to the line description as
+     * "Label: value" lines, so the invoice shows what the customer ordered —
+     * not just the bare product name (#105).
+     *
+     * @return void
+     */
+    public function test_line_description_appends_item_meta() {
+        $item = new \WC_Order_Item_Product('Engraved Pen');
+        $item->set_formatted_meta(array(
+            array('display_key' => 'Engraving', 'display_value' => 'Happy Birthday'),
+            array('display_key' => 'Color',     'display_value' => 'Blue'),
+        ));
+
+        $description = $this->first_line_description($this->make_order_with_item($item));
+
+        $this->assertSame("Engraved Pen\nEngraving: Happy Birthday\nColor: Blue", $description);
+    }
+
+    /**
+     * An item with no visible meta keeps the bare product name — no trailing
+     * separator or empty lines.
+     *
+     * @return void
+     */
+    public function test_line_description_without_meta_is_product_name() {
+        $item = new \WC_Order_Item_Product('Plain Pen');
+
+        $description = $this->first_line_description($this->make_order_with_item($item));
+
+        $this->assertSame('Plain Pen', $description);
+    }
+
+    /**
+     * Meta values are rendered as plain text: HTML is stripped and embedded
+     * line breaks collapse to single spaces, so a rich display value (e.g. a
+     * linked add-on) doesn't break the description.
+     *
+     * @return void
+     */
+    public function test_line_description_strips_tags_from_meta() {
+        $item = new \WC_Order_Item_Product('Gift Box');
+        $item->set_formatted_meta(array(
+            array('display_key' => 'Message', 'display_value' => "<strong>Hello</strong>\nthere"),
+        ));
+
+        $description = $this->first_line_description($this->make_order_with_item($item));
+
+        $this->assertSame("Gift Box\nMessage: Hello there", $description);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -171,6 +171,26 @@ if (!function_exists('wp_kses_post')) {
     }
 }
 
+if (!function_exists('wp_strip_all_tags')) {
+    /**
+     * Mock wp_strip_all_tags function. Strips tags; when $remove_breaks is
+     * true, collapses runs of whitespace (incl. newlines/tabs) to a single
+     * space, matching WordPress core behaviour.
+     *
+     * @param string $text          Text to strip.
+     * @param bool   $remove_breaks Collapse whitespace runs.
+     * @return string
+     */
+    function wp_strip_all_tags($text, $remove_breaks = false) {
+        $text = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', (string) $text);
+        $text = strip_tags($text);
+        if ($remove_breaks) {
+            $text = preg_replace('/[\r\n\t ]+/', ' ', $text);
+        }
+        return trim($text);
+    }
+}
+
 if (!function_exists('wp_date')) {
     /**
      * Mock wp_date function. The real function honors the WP-configured
@@ -1046,6 +1066,7 @@ if (!class_exists('WC_Order_Item_Product')) {
     class WC_Order_Item_Product {
         private $data = array();
         private $product = null;
+        private $formatted_meta = array();
 
         public function __construct($name = 'Test Product') {
             $this->data = array(
@@ -1066,6 +1087,21 @@ if (!class_exists('WC_Order_Item_Product')) {
         public function set_total($total) { $this->data['total'] = $total; }
         public function set_taxes($taxes) { $this->data['taxes'] = $taxes; }
         public function set_product($product) { $this->product = $product; }
+
+        // Mirrors WC_Order_Item::get_formatted_meta_data() — tests seed entries
+        // via set_formatted_meta() with display_key / display_value objects.
+        public function get_formatted_meta_data($hideprefix = '_', $include_all = false) {
+            return $this->formatted_meta;
+        }
+
+        public function set_formatted_meta(array $meta) {
+            $this->formatted_meta = array_map(function ($m) {
+                return (object) array(
+                    'display_key'   => $m['display_key'],
+                    'display_value' => $m['display_value'],
+                );
+            }, $meta);
+        }
     }
 }
 


### PR DESCRIPTION
Invoice lines showed only the product name, dropping the variation and add-on options the customer actually selected. The description now appends WooCommerce's formatted item meta under the product name, using the core formatter so private meta stays hidden, values already in the name aren't duplicated, and plugin display filters are honoured.

Verified against B2Brouter staging: the multi-line description is accepted and stored, with private meta excluded.

Closes #105